### PR TITLE
fix timestamp convert by setting UTC as timezone

### DIFF
--- a/src/main/java/org/embulk/output/bigquery_java/converter/BigqueryTimestampConverter.java
+++ b/src/main/java/org/embulk/output/bigquery_java/converter/BigqueryTimestampConverter.java
@@ -31,8 +31,7 @@ public class BigqueryTimestampConverter {
                 if (src == null) {
                     node.putNull(name);
                 } else {
-                    timezone = columnOption.getTimezone();
-                    timestampFormat = TimestampFormatter.of("%Y-%m-%d %H:%M:%S.%6N %:z", timezone);
+                    timestampFormat = TimestampFormatter.of("%Y-%m-%d %H:%M:%S.%6N %:z", "UTC");
                     node.put(name, timestampFormat.format(src));
                 }
                 break;
@@ -40,8 +39,7 @@ public class BigqueryTimestampConverter {
                 if (src == null) {
                     node.putNull(name);
                 } else {
-                    timezone = columnOption.getTimezone();
-                    timestampFormat = TimestampFormatter.of("%Y-%m-%d %H:%M:%S.%6N", timezone);
+                    timestampFormat = TimestampFormatter.of("%Y-%m-%d %H:%M:%S.%6N", "UTC");
                     node.put(name, timestampFormat.format(src));
                 }
                 break;
@@ -49,8 +47,7 @@ public class BigqueryTimestampConverter {
                 if (src == null) {
                     node.putNull(name);
                 } else {
-                    timezone = columnOption.getTimezone();
-                    timestampFormat = TimestampFormatter.of("%Y-%m-%d", timezone);
+                    timestampFormat = TimestampFormatter.of("%Y-%m-%d", "UTC");
                     node.put(name, timestampFormat.format(src));
                 }
                 break;

--- a/src/main/java/org/embulk/output/bigquery_java/converter/BigqueryTimestampConverter.java
+++ b/src/main/java/org/embulk/output/bigquery_java/converter/BigqueryTimestampConverter.java
@@ -39,7 +39,8 @@ public class BigqueryTimestampConverter {
                 if (src == null) {
                     node.putNull(name);
                 } else {
-                    timestampFormat = TimestampFormatter.of("%Y-%m-%d %H:%M:%S.%6N", "UTC");
+                    timezone = columnOption.getTimezone();
+                    timestampFormat = TimestampFormatter.of("%Y-%m-%d %H:%M:%S.%6N", timezone);
                     node.put(name, timestampFormat.format(src));
                 }
                 break;
@@ -47,7 +48,8 @@ public class BigqueryTimestampConverter {
                 if (src == null) {
                     node.putNull(name);
                 } else {
-                    timestampFormat = TimestampFormatter.of("%Y-%m-%d", "UTC");
+                    timezone = columnOption.getTimezone();
+                    timestampFormat = TimestampFormatter.of("%Y-%m-%d", timezone);
                     node.put(name, timestampFormat.format(src));
                 }
                 break;

--- a/src/test/java/org/embulk/output/bigquery_java/converter/TestBigqueryTimestampConverter.java
+++ b/src/test/java/org/embulk/output/bigquery_java/converter/TestBigqueryTimestampConverter.java
@@ -69,26 +69,7 @@ public class TestBigqueryTimestampConverter {
     }
 
     @Test
-    public void testConvertTimestampToTimestamp() {
-        ObjectNode node = BigqueryUtil.getObjectMapper().createObjectNode();
-        config = loadYamlResource(embulk, "base.yml");
-        ImmutableList.Builder<ConfigSource> builder = ImmutableList.builder();
-        ConfigSource configSource = embulk.newConfig();
-        configSource.set("type", "TIMESTAMP");
-        configSource.set("name", "key");
-        builder.add(configSource);
-        config.set("column_options",builder.build());
-        BigqueryColumnOption columnOption = configSource.loadConfig(BigqueryColumnOption.class);
-        PluginTask task = config.loadConfig(PluginTask.class);
-        // Fri May 01 2020 00:00:00
-        Timestamp ts = Timestamp.ofEpochMilli(1588291200000L);
-
-        BigqueryTimestampConverter.convertAndSet(node, "key", ts, BigqueryColumnOptionType.TIMESTAMP, columnOption, task);
-        assertEquals("2020-05-01 00:00:00.000000 +00:00", node.get("key").asText());
-    }
-
-    @Test
-    public void testConvertTimestampToTimestampWithoutColumnOption() {
+    public void testConvertTimestampToTimestampColumnOption() {
         ObjectNode node = BigqueryUtil.getObjectMapper().createObjectNode();
         config = loadYamlResource(embulk, "base.yml");
         PluginTask task = config.loadConfig(PluginTask.class);

--- a/src/test/java/org/embulk/output/bigquery_java/converter/TestBigqueryTimestampConverter.java
+++ b/src/test/java/org/embulk/output/bigquery_java/converter/TestBigqueryTimestampConverter.java
@@ -88,6 +88,19 @@ public class TestBigqueryTimestampConverter {
     }
 
     @Test
+    public void testConvertTimestampToTimestampWithoutColumnOption() {
+        ObjectNode node = BigqueryUtil.getObjectMapper().createObjectNode();
+        config = loadYamlResource(embulk, "base.yml");
+        PluginTask task = config.loadConfig(PluginTask.class);
+        // Fri May 01 2020 00:00:00
+        Timestamp ts = Timestamp.ofEpochMilli(1588291200000L);
+
+        BigqueryTimestampConverter.convertAndSet(node, "key", ts, BigqueryColumnOptionType.TIMESTAMP, null, task);
+        assertEquals("2020-05-01 00:00:00.000000 +00:00", node.get("key").asText());
+    }
+
+
+    @Test
     public void testConvertTimestampToString() {
         ObjectNode node = BigqueryUtil.getObjectMapper().createObjectNode();
         config = loadYamlResource(embulk, "base.yml");


### PR DESCRIPTION
bigquery timstamp is always UTC. it does not require a time zone.