### PR TITLE
Added merge mode

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,6 +43,7 @@ jobs:
     needs: [ test ]
     if: ${{ github.event_name == 'workflow_dispatch' || contains(github.ref, 'refs/tags/') }}
     steps:
+      - uses: actions/checkout@v2
       - name: push gem
         uses: trocco-io/push-gem-to-gpr-action@v1
         with:

--- a/src/main/java/org/embulk/output/bigquery_java/config/BigqueryConfigValidator.java
+++ b/src/main/java/org/embulk/output/bigquery_java/config/BigqueryConfigValidator.java
@@ -13,17 +13,17 @@ public class BigqueryConfigValidator {
 
     public static void validateMode(PluginTask task) throws ConfigException {
         // TODO: append_direct delete_in_advance replace_backup
-        String[] modes = {"replace", "append", "delete_in_advance", "append_direct"};
+        String[] modes = {"replace", "append", "merge", "delete_in_advance", "append_direct"};
         if (!Arrays.asList(modes).contains(task.getMode().toLowerCase())) {
-            throw new ConfigException("replace, append, delete_in_advance and append_direct are supported. Stay tuned!");
+            throw new ConfigException("replace, append, merge, delete_in_advance and append_direct are supported. Stay tuned!");
         }
     }
 
     public static void validateModeAndAutoCreteTable(PluginTask task) throws ConfigException {
         // TODO: modes are append replace delete_in_advance replace_backup and !task['auto_create_table']
-        String[] modes = {"replace", "append", "delete_in_advance"};
+        String[] modes = {"replace", "append", "merge", "delete_in_advance"};
         if (Arrays.asList(modes).contains(task.getMode().toLowerCase()) && !task.getAutoCreateTable()) {
-            throw new ConfigException("replace, append and delete_in_advance are supported. Stay tuned!");
+            throw new ConfigException("replace, append, merge and delete_in_advance are supported. Stay tuned!");
         }
     }
 

--- a/src/main/java/org/embulk/output/bigquery_java/config/BigqueryTaskBuilder.java
+++ b/src/main/java/org/embulk/output/bigquery_java/config/BigqueryTaskBuilder.java
@@ -1,12 +1,12 @@
 package org.embulk.output.bigquery_java.config;
 
+import com.google.common.annotations.VisibleForTesting;
+
 import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.UUID;
 import java.util.Optional;
-
-import com.google.common.annotations.VisibleForTesting;
+import java.util.UUID;
 
 public class BigqueryTaskBuilder {
     private static final String uniqueName = UUID.randomUUID().toString().replace("-", "_");
@@ -50,7 +50,7 @@ public class BigqueryTaskBuilder {
     @VisibleForTesting
     protected static void setTempTable(PluginTask task) {
         // TODO: support replace_backup
-        String[] modeForTempTable = {"replace", "append", "delete_in_advance"};
+        String[] modeForTempTable = {"replace", "append", "merge", "delete_in_advance"};
         if (Arrays.asList(modeForTempTable).contains(task.getMode())) {
             String tempTable = task.getTempTable().orElse(String.format("LOAD_TEMP_%s_%s", uniqueName, task.getTable()));
             task.setTempTable(Optional.of(tempTable));

--- a/src/main/java/org/embulk/output/bigquery_java/config/PluginTask.java
+++ b/src/main/java/org/embulk/output/bigquery_java/config/PluginTask.java
@@ -158,4 +158,12 @@ public interface PluginTask
     @Config("clustering")
     @ConfigDefault("null")
     Optional<BigqueryClustering> getClustering();
+
+    @Config("merge_keys")
+    @ConfigDefault("null")
+    Optional<List<String>> getMergeKeys();
+
+    @Config("merge_rule")
+    @ConfigDefault("null")
+    Optional<List<String>> getMergeRule();
 }


### PR DESCRIPTION
<details>
<summary>create table</summary>

```
CREATE TABLE `test_by_sano`.`output` (
  `key_long` INT64 NOT NULL,
  `key_string` STRING NOT NULL,
  `test_boolean` BOOL,
  `test_long` INT64,
  `test_double` FLOAT64,
  `test_string` STRING,
  `test_timestamp` TIMESTAMP,
  `test_json` STRING,
  PRIMARY KEY(`key_long`, `key_string`) NOT ENFORCED
);
```

</details>
<details>
<summary>test jsonl</summary>

```
$ cat test_1.jsonl
{"key_long":1,"key_string":"a","test_boolean":true,"test_long":123,"test_double":1.23,"test_string":"あいうえお","test_timestamp":"1999-12-31 23:59:59.000000 +0000","test_json":{"キー":"値"}}
{"key_long":2,"key_string":"b","test_boolean":false,"test_long":456,"test_double":4.56,"test_string":"かきくけこ","test_timestamp":"2000-01-01 00:00:00.000000 +0000","test_json":[{"キー1":"値1"},{"キー2":"値2"}]}
{"key_long":3,"key_string":"c","test_boolean":null,"test_long":null,"test_double":null,"test_string":null,"test_timestamp":null,"test_json":null}
{"key_long":4,"key_string":"d","test_boolean":null,"test_long":null,"test_double":null,"test_string":null,"test_timestamp":null,"test_json":12345}
{"key_long":5,"key_string":"e","test_boolean":null,"test_long":null,"test_double":null,"test_string":null,"test_timestamp":null,"test_json":123.45}
{"key_long":6,"key_string":"f","test_boolean":null,"test_long":null,"test_double":null,"test_string":null,"test_timestamp":null,"test_json":"hoge"}

$ cat test_2.jsonl
{"key_long":1,"key_string":"a","test_boolean":true,"test_long":123,"test_double":1.23,"test_string":"あいうえお","test_timestamp":"1999-12-31 23:59:59.000000 +0000","test_json":{"キー":"値"}}
{"key_long":3,"key_string":"c","test_boolean":false,"test_long":456,"test_double":4.56,"test_string":"かきくけこ","test_timestamp":"2000-01-01 00:00:00.000000 +0000","test_json":[{"キー1":"値1"},{"キー2":"値2"}]}
{"key_long":5,"key_string":"e","test_boolean":null,"test_long":null,"test_double":null,"test_string":null,"test_timestamp":null,"test_json":null}
{"key_long":7,"key_string":"g","test_boolean":null,"test_long":null,"test_double":null,"test_string":null,"test_timestamp":null,"test_json":12345}
{"key_long":8,"key_string":"h","test_boolean":null,"test_long":null,"test_double":null,"test_string":null,"test_timestamp":null,"test_json":123.45}
{"key_long":9,"key_string":"i","test_boolean":null,"test_long":null,"test_double":null,"test_string":null,"test_timestamp":null,"test_json":"hoge"}
```

</details>
<details>
<summary>config</summary>

```
$ cat config_out.yml
in:
  type: file
  path_prefix: test_1.jsonl
  parser:
    type: jsonl
    columns:
    - {name: key_long, type: long}
    - {name: key_string, type: string}
    - {name: test_boolean, type: boolean}
    - {name: test_long, type: long}
    - {name: test_double, type: double}
    - {name: test_string, type: string}
    - {name: test_timestamp, type: timestamp}
    - {name: test_json, type: json}
out:
  type: bigquery_java
  auth_method: service_account
  json_keyfile: key.json
  dataset: test_by_sano
  table: output
  location: US
  compression: GZIP
  source_format: NEWLINE_DELIMITED_JSON
  mode: merge
  merge_keys: []
  merge_rule: []

$ cat config_in.yml
in:
  type: bigquery
  project: systemn-playground
  keyfile: key.json
  sql: SELECT * FROM `test_by_sano`.`output` ORDER BY `key_long`, `key_string`
  location: US
out:
  type: command
  command: 'cat -'
  formatter:
    type: jsonl
```

</details>
<details>
<summary>run test 1</summary>

```
$ embulk run config_out.yml
2024-07-17 03:16:26.190 +0000: Embulk v0.9.26
2024-07-17 03:16:26.820 +0000 [WARN] (main): DEPRECATION: JRuby org.jruby.embed.ScriptingContainer is directly injected.
2024-07-17 03:16:28.139 +0000 [INFO] (main): Gem's home and path are set by default: "/home/ubuntu/.embulk/lib/gems"
2024-07-17 03:16:28.853 +0000 [INFO] (main): Started Embulk v0.9.26
2024-07-17 03:16:28.959 +0000 [INFO] (0001:transaction): Loaded plugin embulk-output-bigquery_java (0.1.2)
2024-07-17 03:16:28.987 +0000 [INFO] (0001:transaction): Loaded plugin embulk-parser-jsonl (0.2.1)
2024-07-17 03:16:29.002 +0000 [INFO] (0001:transaction): Listing local files at directory '.' filtering filename by prefix 'test_1.jsonl'
2024-07-17 03:16:29.003 +0000 [INFO] (0001:transaction): "follow_symlinks" is set false. Note that symbolic links to directories are skipped.
2024-07-17 03:16:29.005 +0000 [INFO] (0001:transaction): Loading files [test_1.jsonl]
2024-07-17 03:16:29.032 +0000 [INFO] (0001:transaction): Using local thread executor with max_threads=16 / output tasks 8 = input tasks 1 * 8
2024-07-17 03:16:30.646 +0000 [INFO] (0001:transaction): {done:  0 / 1, running: 0}
2024-07-17 03:16:30.727 +0000 [INFO] (embulk-output-executor-0): embulk-output-bigquery: create /tmp/embulk_output_bigquery_java3383328164259463604.5530.19.jsonl.gz
2024-07-17 03:16:30.729 +0000 [INFO] (0001:transaction): {done:  1 / 1, running: 0}
2024-07-17 03:16:30.729 +0000 [INFO] (0001:transaction): embulk-output-bigquery: finish to create intermediate files
2024-07-17 03:16:30.735 +0000 [INFO] (pool-3-thread-1): embulk-output-bigquery: Load job starting... job_id:[embulk_load_job_3e105cb6-0aa8-420c-802d-e5f577125dd1] /tmp/embulk_output_bigquery_java3383328164259463604.5530.19.jsonl.gz => test_by_sano.LOAD_TEMP_b7c8436b_de2e_458b_8ab0_faf969b1ed9c_output in US
2024-07-17 03:16:33.420 +0000 [INFO] (pool-3-thread-1): embulk-output-bigquery: Load job checking...
2024-07-17 03:16:33.420 +0000 [INFO] (pool-3-thread-1): job_id[embulk_load_job_3e105cb6-0aa8-420c-802d-e5f577125dd1] elapsed_time 0 sec status[RUNNING]
2024-07-17 03:16:43.740 +0000 [INFO] (pool-3-thread-1): embulk-output-bigquery: Load job completed...
2024-07-17 03:16:43.740 +0000 [INFO] (pool-3-thread-1): job_id:embulk_load_job_3e105cb6-0aa8-420c-802d-e5f577125dd1 elapsed_time 10 sec status[DONE]
2024-07-17 03:16:43.741 +0000 [INFO] (pool-3-thread-1): embulk-output-bigquery: Load job response... job_id:[embulk_load_job_3e105cb6-0aa8-420c-802d-e5f577125dd1] response.statistics:LoadStatistics{creationTime=1721186192747, endTime=1721186194456, startTime=1721186192986, numChildJobs=null, parentJobId=null, scriptStatistics=null, reservationUsage=null, transactionInfo=null, sessionInfo=null, inputBytes=1039, inputFiles=1, outputBytes=232, outputRows=6, badRecords=0}
2024-07-17 03:16:45.471 +0000 [INFO] (0001:transaction): embulk-output-bigquery: Execute query... MERGE `test_by_sano`.`output` T USING `test_by_sano`.`LOAD_TEMP_b7c8436b_de2e_458b_8ab0_faf969b1ed9c_output` S ON T.`key_long` = S.`key_long` AND T.`key_string` = S.`key_string` WHEN MATCHED THEN UPDATE SET T.`key_long` = S.`key_long`, T.`key_string` = S.`key_string`, T.`test_boolean` = S.`test_boolean`, T.`test_long` = S.`test_long`, T.`test_double` = S.`test_double`, T.`test_string` = S.`test_string`, T.`test_timestamp` = S.`test_timestamp`, T.`test_json` = S.`test_json` WHEN NOT MATCHED THEN INSERT (`key_long`, `key_string`, `test_boolean`, `test_long`, `test_double`, `test_string`, `test_timestamp`, `test_json`) VALUES (`key_long`, `key_string`, `test_boolean`, `test_long`, `test_double`, `test_string`, `test_timestamp`, `test_json`)
2024-07-17 03:16:46.741 +0000 [INFO] (0001:transaction): embulk-output-bigquery: Query job checking...
2024-07-17 03:16:46.741 +0000 [INFO] (0001:transaction): job_id[embulk_query_job_438c52ab-3a2f-4fa9-833c-ce0ec0376410] elapsed_time 0 sec status[RUNNING]
2024-07-17 03:16:57.031 +0000 [INFO] (0001:transaction): embulk-output-bigquery: Query job completed...
2024-07-17 03:16:57.031 +0000 [INFO] (0001:transaction): job_id:embulk_query_job_438c52ab-3a2f-4fa9-833c-ce0ec0376410 elapsed_time 10 sec status[DONE]
2024-07-17 03:16:57.032 +0000 [INFO] (0001:transaction): embulk-output-bigquery: Query job response... job_id:[embulk_query_job_438c52ab-3a2f-4fa9-833c-ce0ec0376410] response.statistics:QueryStatistics{creationTime=1721186205662, endTime=1721186208211, startTime=1721186206341, numChildJobs=null, parentJobId=null, scriptStatistics=null, reservationUsage=null, transactionInfo=null, sessionInfo=null, biEngineStats=null, billingTier=1, cacheHit=false, totalBytesBilled=20971520, totalBytesProcessed=232, queryPlan=[QueryStage{completedParallelInputs=1, computeMsAvg=9, computeMsMax=9, computeRatioAvg=0.03896103896103896, computeRatioMax=0.03896103896103896, endMs=1721186206677, generatedId=0, inputStages=null, name=S00: Input, parallelInputs=1, readMsAvg=0, readMsMax=0, readRatioAvg=0.0, readRatioMax=0.0, recordsRead=0, recordsWritten=0, shuffleOutputBytes=0, shuffleOutputBytesSpilled=0, startMs=1721186206618, status=COMPLETE, steps=[QueryStep{name=READ, substeps=[$10:key_long, $11:key_string, $12:$file_temp_id, $13:$row_temp_id, FROM test_by_sano.output]}, QueryStep{name=COMPUTE, substeps=[$150 := 1]}, QueryStep{name=WRITE, substeps=[$10, $11, $12, $13, $150, TO __stage00_output]}], waitMsAvg=1, waitMsMax=1, waitRatioAvg=0.004329004329004329, waitRatioMax=0.004329004329004329, writeMsAvg=54, writeMsMax=54, writeRatioAvg=0.23376623376623376, writeRatioMax=0.23376623376623376, slotMs=131}, QueryStage{completedParallelInputs=100, computeMsAvg=9, computeMsMax=16, computeRatioAvg=0.03896103896103896, computeRatioMax=0.06926406926406926, endMs=1721186206756, generatedId=1, inputStages=[0], name=S01: Coalesce, parallelInputs=100, readMsAvg=0, readMsMax=0, readRatioAvg=0.0, readRatioMax=0.0, recordsRead=0, recordsWritten=0, shuffleOutputBytes=0, shuffleOutputBytesSpilled=0, startMs=1721186206679, status=COMPLETE, steps=[QueryStep{name=READ, substeps=[FROM __stage00_output]}], waitMsAvg=1, waitMsMax=2, waitRatioAvg=0.004329004329004329, waitRatioMax=0.008658008658008658, writeMsAvg=38, writeMsMax=66, writeRatioAvg=0.1645021645021645, writeRatioMax=0.2857142857142857, slotMs=8085}, QueryStage{completedParallelInputs=1, computeMsAvg=12, computeMsMax=12, computeRatioAvg=0.05194805194805195, computeRatioMax=0.05194805194805195, endMs=1721186206771, generatedId=2, inputStages=[1], name=S02: Join+, parallelInputs=1, readMsAvg=6, readMsMax=6, readRatioAvg=0.025974025974025976, readRatioMax=0.025974025974025976, recordsRead=6, recordsWritten=6, shuffleOutputBytes=756, shuffleOutputBytesSpilled=0, startMs=1721186206685, status=COMPLETE, steps=[QueryStep{name=READ, substeps=[$1:key_long, $2:key_string, $3:test_boolean, $4:test_long, $5:test_double, $6:test_string, $7:test_timestamp, $8:test_json, FROM test_by_sano.LOAD_TEMP_b7c8436b_de2e_458b_8ab0_faf969b1ed9c_output]}, QueryStep{name=READ, substeps=[$10, $11, $12, $13, $150, FROM __stage01_output]}, QueryStep{name=AGGREGATE, substeps=[GROUP BY $180 := $101, $181 := $102, $182 := $90, $70 := ANY_AND_CHECK_FOR_UPDATE($121), $71 := ANY_AND_CHECK_FOR_UPDATE($120), $72 := ANY_AND_CHECK_FOR_UPDATE($122), $73 := ANY_AND_CHECK_FOR_UPDATE($123), $74 := ANY_AND_CHECK_FOR_UPDATE($124), $75 := ANY_AND_CHECK_FOR_UPDATE($125), $76 := ANY_AND_CHECK_FOR_UPDATE($126), $77 := ANY_AND_CHECK_FOR_UPDATE($127), $78 := ANY_AND_CHECK_FOR_UPDATE($128), $79 := ANY_AND_CHECK_FOR_UPDATE($129), $80 := ANY_AND_CHECK_FOR_UPDATE($141), $81 := ANY_AND_CHECK_FOR_UPDATE($142), $82 := ANY_AND_CHECK_FOR_UPDATE($143), $83 := ANY_AND_CHECK_FOR_UPDATE($144), $84 := ANY_AND_CHECK_FOR_UPDATE($145), $85 := ANY_AND_CHECK_FOR_UPDATE($146)]}, QueryStep{name=COMPUTE, substeps=[$90 := if(equal($120, 10001), $100, NULL)]}, QueryStep{name=COMPUTE, substeps=[$100 := UNIQUE_ROW_ID(), $101 := if(equal($120, 10001), SAFE_EXPR(CAST(add(1000000000, abs(mod(farm_fingerprint($110), 1000000000))) AS UINT64)), $160), $102 := if(equal($120, 10001), 18446744073709551615, $161)]}, QueryStep{name=COMPUTE, substeps=[$110 := UNIQUE_ROW_ID()]}, QueryStep{name=FILTER, substeps=[not(equal($120, 0))]}, QueryStep{name=COMPUTE, substeps=[$120 := if($130, 10001, $140), $121 := if($130, 2, if(not(is_null($162)), 1, -1)), $122 := if($130, $163, NULL), $123 := if($130, $164, NULL), $124 := if($130, $165, NULL), $125 := if($130, $166, NULL), $126 := if($130, $167, NULL), $127 := if($130, $168, NULL), $128 := if($130, $169, NULL), $129 := if($130, $170, NULL)]}, QueryStep{name=COMPUTE, substeps=[$130 := and(equal($140, 0), is_null($162))]}, QueryStep{name=COMPUTE, substeps=[$140 := if(not(is_null($162)), 10002, 0), $141 := if(not(is_null($162)), $163, NULL), $142 := if(not(is_null($162)), $164, NULL), $143 := if(not(is_null($162)), $165, NULL), $144 := if(not(is_null($162)), $166, NULL), $145 := if(not(is_null($162)), $167, NULL), $146 := if(not(is_null($162)), $168, NULL), $147 := if(not(is_null($162)), $169, NULL), $148 := if(not(is_null($162)), $170, NULL)]}, QueryStep{name=JOIN, substeps=[$163 := $1, $164 := $2, $165 := $3, $166 := $4, $167 := $5, $168 := $6, $169 := $7, $170 := $8, $160 := $12, $161 := $13, $162 := $150, LEFT OUTER HASH JOIN EACH  WITH ALL  ON $1 = $10, $2 = $11]}, QueryStep{name=WRITE, substeps=[$70, $71, $72, $73, $74, $75, $76, $77, $78, $79, $80, $81, $82, $83, $84, $85, TO __stage02_output, BY HASH($180, $181, $182)]}], waitMsAvg=6, waitMsMax=6, waitRatioAvg=0.025974025974025976, waitRatioMax=0.025974025974025976, writeMsAvg=3, writeMsMax=3, writeRatioAvg=0.012987012987012988, writeRatioMax=0.012987012987012988, slotMs=37}, QueryStage{completedParallelInputs=1, computeMsAvg=7, computeMsMax=7, computeRatioAvg=0.030303030303030304, computeRatioMax=0.030303030303030304, endMs=1721186206791, generatedId=3, inputStages=[2], name=S03: Aggregate, parallelInputs=1, readMsAvg=0, readMsMax=0, readRatioAvg=0.0, readRatioMax=0.0, recordsRead=6, recordsWritten=6, shuffleOutputBytes=570, shuffleOutputBytesSpilled=0, startMs=1721186206781, status=COMPLETE, steps=[QueryStep{name=READ, substeps=[$70, $71, $72, $73, $74, $75, $76, $77, $78, $79, $80, $81, $82, $83, $84, $85, FROM __stage02_output]}, QueryStep{name=AGGREGATE, substeps=[GROUP BY $190 := $180, $191 := $181, $192 := $182, $50 := ANY_AND_CHECK_FOR_UPDATE($70), $51 := ANY_AND_CHECK_FOR_UPDATE($71), $52 := ANY_AND_CHECK_FOR_UPDATE($72), $53 := ANY_AND_CHECK_FOR_UPDATE($73), $54 := ANY_AND_CHECK_FOR_UPDATE($74), $55 := ANY_AND_CHECK_FOR_UPDATE($75), $56 := ANY_AND_CHECK_FOR_UPDATE($76), $57 := ANY_AND_CHECK_FOR_UPDATE($77), $58 := ANY_AND_CHECK_FOR_UPDATE($78), $59 := ANY_AND_CHECK_FOR_UPDATE($79), $60 := ANY_AND_CHECK_FOR_UPDATE($80), $61 := ANY_AND_CHECK_FOR_UPDATE($81), $62 := ANY_AND_CHECK_FOR_UPDATE($82), $63 := ANY_AND_CHECK_FOR_UPDATE($83), $64 := ANY_AND_CHECK_FOR_UPDATE($84), $65 := ANY_AND_CHECK_FOR_UPDATE($85)]}, QueryStep{name=WRITE, substeps=[$50, $51, $52, $53, $54, $55, $56, $57, $58, $59, $60, $61, $62, $63, $64, $65, TO __stage03_output, BY HASH($190)]}], waitMsAvg=1, waitMsMax=1, waitRatioAvg=0.004329004329004329, waitRatioMax=0.004329004329004329, writeMsAvg=3, writeMsMax=3, writeRatioAvg=0.012987012987012988, writeRatioMax=0.012987012987012988, slotMs=12}, QueryStage{completedParallelInputs=1, computeMsAvg=12, computeMsMax=12, computeRatioAvg=0.05194805194805195, computeRatioMax=0.05194805194805195, endMs=1721186206887, generatedId=4, inputStages=[3], name=S04: Sort+, parallelInputs=1, readMsAvg=0, readMsMax=0, readRatioAvg=0.0, readRatioMax=0.0, recordsRead=6, recordsWritten=6, shuffleOutputBytes=270, shuffleOutputBytesSpilled=0, startMs=1721186206827, status=COMPLETE, steps=[QueryStep{name=READ, substeps=[$50, $51, $52, $53, $54, $55, $56, $57, $58, $59, $60, $61, $62, $63, $64, $65, FROM __stage03_output]}, QueryStep{name=COMPUTE, substeps=[$20 := if(equal(2, $30), $221, if(equal(1, $30), $229, $40)), $21 := if(equal(2, $30), $222, if(equal(1, $30), $230, $41)), $22 := if(equal(2, $30), $223, if(equal(1, $30), $231, $42)), $23 := if(equal(2, $30), $224, if(equal(1, $30), $232, $43)), $24 := if(equal(2, $30), $225, if(equal(1, $30), $233, $44)), $25 := if(equal(2, $30), $226, if(equal(1, $30), $234, $45)), $26 := if(equal(2, $30), $227, if(equal(1, $30), $235, $46)), $27 := if(equal(2, $30), $228, if(equal(1, $30), $236, $47)), $28 := if(equal(-1, $30), 'REINSERT', if(in($30, 1), 'UPDATE', NULL))]}, QueryStep{name=COMPUTE, substeps=[$30 := if(not($48), -1, $220)]}, QueryStep{name=SORT, substeps=[$190 ASC, $191 DESC]}, QueryStep{name=WRITE, substeps=[$20, $21, $22, $23, $24, $25, $26, $27, $28, TO __stage04_output]}], waitMsAvg=2, waitMsMax=2, waitRatioAvg=0.008658008658008658, waitRatioMax=0.008658008658008658, writeMsAvg=52, writeMsMax=52, writeRatioAvg=0.22510822510822512, writeRatioMax=0.22510822510822512, slotMs=70}, QueryStage{completedParallelInputs=50, computeMsAvg=10, computeMsMax=15, computeRatioAvg=0.04329004329004329, computeRatioMax=0.06493506493506493, endMs=1721186206955, generatedId=5, inputStages=[4], name=S05: Coalesce, parallelInputs=50, readMsAvg=0, readMsMax=0, readRatioAvg=0.0, readRatioMax=0.0, recordsRead=6, recordsWritten=6, shuffleOutputBytes=270, shuffleOutputBytesSpilled=0, startMs=1721186206893, status=COMPLETE, steps=[QueryStep{name=READ, substeps=[FROM __stage04_output]}], waitMsAvg=5, waitMsMax=9, waitRatioAvg=0.021645021645021644, waitRatioMax=0.03896103896103896, writeMsAvg=35, writeMsMax=52, writeRatioAvg=0.15151515151515152, writeRatioMax=0.22510822510822512, slotMs=3077}, QueryStage{completedParallelInputs=1, computeMsAvg=15, computeMsMax=15, computeRatioAvg=0.06493506493506493, computeRatioMax=0.06493506493506493, endMs=1721186207277, generatedId=6, inputStages=[5], name=S06: Output, parallelInputs=1, readMsAvg=0, readMsMax=0, readRatioAvg=0.0, readRatioMax=0.0, recordsRead=6, recordsWritten=6, shuffleOutputBytes=0, shuffleOutputBytesSpilled=0, startMs=1721186207122, status=COMPLETE, steps=[QueryStep{name=READ, substeps=[$20, $21, $22, $23, $24, $25, $26, $27, $28, FROM __stage05_output]}, QueryStep{name=WRITE, substeps=[$20, $21, $22, $23, $24, $25, $26, $27, TO __stage06_output]}], waitMsAvg=231, waitMsMax=231, waitRatioAvg=1.0, waitRatioMax=1.0, writeMsAvg=144, writeMsMax=144, writeRatioAvg=0.6233766233766234, writeRatioMax=0.6233766233766234, slotMs=429}], timeline=[TimelineSample{elapsedMs=777, activeUnits=0, completedUnits=154, pendingUnits=1, slotMillis=11415}, TimelineSample{elapsedMs=944, activeUnits=null, completedUnits=155, pendingUnits=0, slotMillis=11844}], schema=null, queryParameters=null}
2024-07-17 03:16:57.033 +0000 [INFO] (0001:transaction): embulk-output-bigquery: Delete table... test_by_sano.LOAD_TEMP_b7c8436b_de2e_458b_8ab0_faf969b1ed9c_output
2024-07-17 03:16:57.442 +0000 [INFO] (main): Committed.
2024-07-17 03:16:57.442 +0000 [INFO] (main): Next config diff: {"in":{"last_path":"test_1.jsonl"},"out":{}}

$ embulk run config_in.yml
2024-07-17 03:17:03.569 +0000: Embulk v0.9.26
2024-07-17 03:17:04.200 +0000 [WARN] (main): DEPRECATION: JRuby org.jruby.embed.ScriptingContainer is directly injected.
2024-07-17 03:17:05.513 +0000 [INFO] (main): Gem's home and path are set by default: "/home/ubuntu/.embulk/lib/gems"
2024-07-17 03:17:06.173 +0000 [INFO] (main): Started Embulk v0.9.26
WARNING: You are running Ruby 2.3.3, which is nearing end-of-life.
The Google Cloud API clients work best on supported versions of Ruby. Consider upgrading to Ruby 2.4 or later.
See https://www.ruby-lang.org/en/downloads/branches/ for more info on the Ruby maintenance schedule.
To suppress this message, set the GOOGLE_CLOUD_SUPPRESS_RUBY_WARNINGS environment variable.
2024-07-17 03:17:09.430 +0000 [INFO] (0001:transaction): Loaded plugin embulk-input-bigquery (0.1.0)
2024-07-17 03:17:09.457 +0000 [INFO] (0001:transaction): Loaded plugin embulk-output-command (0.1.4)
2024-07-17 03:17:10.081 +0000 [INFO] (0001:transaction): determine columns using the getQueryResults API instead of the config.yml
2024-07-17 03:17:11.020 +0000 [INFO] (0001:transaction): waiting for the query job to complete to get schema from query results
2024-07-17 03:17:11.020 +0000 [INFO] (0001:transaction): completed: job_id=job_fNGXXOo5HXG1saNA63oTmlkVDGLu
2024-07-17 03:17:11.889 +0000 [INFO] (0001:transaction): determined columns: [{"name"=>"key_long", "type"=>:long}, {"name"=>"key_string", "type"=>:string}, {"name"=>"test_boolean", "type"=>:boolean}, {"name"=>"test_long", "type"=>:long}, {"name"=>"test_double", "type"=>:double}, {"name"=>"test_string", "type"=>:string}, {"name"=>"test_timestamp", "type"=>:timestamp}, {"name"=>"test_json", "type"=>:string}]
2024-07-17 03:17:11.896 +0000 [INFO] (0001:transaction): Using local thread executor with max_threads=16 / output tasks 8 = input tasks 1 * 8
2024-07-17 03:17:11.925 +0000 [INFO] (0001:transaction): Loaded plugin embulk-formatter-jsonl (0.1.4)
2024-07-17 03:17:11.938 +0000 [INFO] (0001:transaction): {done:  0 / 1, running: 0}
2024-07-17 03:17:11.947 +0000 [INFO] (0023:task-0000): Using command [sh, -c, cat -]
2024-07-17 03:17:11.958 +0000 [INFO] (0023:task-0000): Using command [sh, -c, cat -]
2024-07-17 03:17:11.960 +0000 [INFO] (0023:task-0000): Using command [sh, -c, cat -]
2024-07-17 03:17:11.962 +0000 [INFO] (0023:task-0000): Using command [sh, -c, cat -]
2024-07-17 03:17:11.964 +0000 [INFO] (0023:task-0000): Using command [sh, -c, cat -]
2024-07-17 03:17:11.967 +0000 [INFO] (0023:task-0000): Using command [sh, -c, cat -]
2024-07-17 03:17:11.970 +0000 [INFO] (0023:task-0000): Using command [sh, -c, cat -]
2024-07-17 03:17:11.972 +0000 [INFO] (0023:task-0000): Using command [sh, -c, cat -]
{"key_long":1,"key_string":"a","test_boolean":true,"test_long":123,"test_double":1.23,"test_string":"あいうえお","test_timestamp":"1999-12-31 23:59:59 +0000","test_json":"{\"キー\":\"値\"}"}
{"key_long":2,"key_string":"b","test_boolean":false,"test_long":456,"test_double":4.56,"test_string":"かきくけこ","test_timestamp":"2000-01-01 00:00:00 +0000","test_json":"[{\"キー1\":\"値1\"},{\"キー2\":\"値2\"}]"}
{"key_long":3,"key_string":"c","test_boolean":null,"test_long":null,"test_double":null,"test_string":null,"test_timestamp":null,"test_json":null}
{"key_long":4,"key_string":"d","test_boolean":null,"test_long":null,"test_double":null,"test_string":null,"test_timestamp":null,"test_json":"12345"}
{"key_long":5,"key_string":"e","test_boolean":null,"test_long":null,"test_double":null,"test_string":null,"test_timestamp":null,"test_json":"123.45"}
{"key_long":6,"key_string":"f","test_boolean":null,"test_long":null,"test_double":null,"test_string":null,"test_timestamp":null,"test_json":"\"hoge\""}
2024-07-17 03:17:13.307 +0000 [INFO] (0001:transaction): {done:  1 / 1, running: 0}
2024-07-17 03:17:13.314 +0000 [INFO] (main): Committed.
2024-07-17 03:17:13.314 +0000 [INFO] (main): Next config diff: {"in":{},"out":{}}
```

</details>
<details>
<summary>run test 2</summary>

```
$ embulk run config_out.yml
2024-07-17 03:18:42.896 +0000: Embulk v0.9.26
2024-07-17 03:18:43.501 +0000 [WARN] (main): DEPRECATION: JRuby org.jruby.embed.ScriptingContainer is directly injected.
2024-07-17 03:18:44.845 +0000 [INFO] (main): Gem's home and path are set by default: "/home/ubuntu/.embulk/lib/gems"
2024-07-17 03:18:45.422 +0000 [INFO] (main): Started Embulk v0.9.26
2024-07-17 03:18:45.521 +0000 [INFO] (0001:transaction): Loaded plugin embulk-output-bigquery_java (0.1.2)
2024-07-17 03:18:45.545 +0000 [INFO] (0001:transaction): Loaded plugin embulk-parser-jsonl (0.2.1)
2024-07-17 03:18:45.556 +0000 [INFO] (0001:transaction): Listing local files at directory '.' filtering filename by prefix 'test_2.jsonl'
2024-07-17 03:18:45.557 +0000 [INFO] (0001:transaction): "follow_symlinks" is set false. Note that symbolic links to directories are skipped.
2024-07-17 03:18:45.560 +0000 [INFO] (0001:transaction): Loading files [test_2.jsonl]
2024-07-17 03:18:45.580 +0000 [INFO] (0001:transaction): Using local thread executor with max_threads=16 / output tasks 8 = input tasks 1 * 8
2024-07-17 03:18:46.922 +0000 [INFO] (0001:transaction): {done:  0 / 1, running: 0}
2024-07-17 03:18:46.991 +0000 [INFO] (embulk-output-executor-0): embulk-output-bigquery: create /tmp/embulk_output_bigquery_java2751230976554284348.5642.19.jsonl.gz
2024-07-17 03:18:46.992 +0000 [INFO] (0001:transaction): {done:  1 / 1, running: 0}
2024-07-17 03:18:46.993 +0000 [INFO] (0001:transaction): embulk-output-bigquery: finish to create intermediate files
2024-07-17 03:18:47.000 +0000 [INFO] (pool-3-thread-1): embulk-output-bigquery: Load job starting... job_id:[embulk_load_job_e29b8abe-3f80-4107-85eb-bbc044ffc41d] /tmp/embulk_output_bigquery_java2751230976554284348.5642.19.jsonl.gz => test_by_sano.LOAD_TEMP_767ab041_eca5_4589_9377_8c4696e1cfc1_output in US
2024-07-17 03:18:49.771 +0000 [INFO] (pool-3-thread-1): embulk-output-bigquery: Load job checking...
2024-07-17 03:18:49.771 +0000 [INFO] (pool-3-thread-1): job_id[embulk_load_job_e29b8abe-3f80-4107-85eb-bbc044ffc41d] elapsed_time 0 sec status[RUNNING]
2024-07-17 03:19:00.047 +0000 [INFO] (pool-3-thread-1): embulk-output-bigquery: Load job completed...
2024-07-17 03:19:00.047 +0000 [INFO] (pool-3-thread-1): job_id:embulk_load_job_e29b8abe-3f80-4107-85eb-bbc044ffc41d elapsed_time 10 sec status[DONE]
2024-07-17 03:19:00.049 +0000 [INFO] (pool-3-thread-1): embulk-output-bigquery: Load job response... job_id:[embulk_load_job_e29b8abe-3f80-4107-85eb-bbc044ffc41d] response.statistics:LoadStatistics{creationTime=1721186329051, endTime=1721186330942, startTime=1721186329291, numChildJobs=null, parentJobId=null, scriptStatistics=null, reservationUsage=null, transactionInfo=null, sessionInfo=null, inputBytes=1039, inputFiles=1, outputBytes=232, outputRows=6, badRecords=0}
2024-07-17 03:19:01.956 +0000 [INFO] (0001:transaction): embulk-output-bigquery: Execute query... MERGE `test_by_sano`.`output` T USING `test_by_sano`.`LOAD_TEMP_767ab041_eca5_4589_9377_8c4696e1cfc1_output` S ON T.`key_long` = S.`key_long` AND T.`key_string` = S.`key_string` WHEN MATCHED THEN UPDATE SET T.`key_long` = S.`key_long`, T.`key_string` = S.`key_string`, T.`test_boolean` = S.`test_boolean`, T.`test_long` = S.`test_long`, T.`test_double` = S.`test_double`, T.`test_string` = S.`test_string`, T.`test_timestamp` = S.`test_timestamp`, T.`test_json` = S.`test_json` WHEN NOT MATCHED THEN INSERT (`key_long`, `key_string`, `test_boolean`, `test_long`, `test_double`, `test_string`, `test_timestamp`, `test_json`) VALUES (`key_long`, `key_string`, `test_boolean`, `test_long`, `test_double`, `test_string`, `test_timestamp`, `test_json`)
2024-07-17 03:19:03.078 +0000 [INFO] (0001:transaction): embulk-output-bigquery: Query job checking...
2024-07-17 03:19:03.078 +0000 [INFO] (0001:transaction): job_id[embulk_query_job_419a3f9b-bca0-4ee2-bf46-8f89615c6a97] elapsed_time 0 sec status[RUNNING]
2024-07-17 03:19:13.381 +0000 [INFO] (0001:transaction): embulk-output-bigquery: Query job completed...
2024-07-17 03:19:13.381 +0000 [INFO] (0001:transaction): job_id:embulk_query_job_419a3f9b-bca0-4ee2-bf46-8f89615c6a97 elapsed_time 10 sec status[DONE]
2024-07-17 03:19:13.383 +0000 [INFO] (0001:transaction): embulk-output-bigquery: Query job response... job_id:[embulk_query_job_419a3f9b-bca0-4ee2-bf46-8f89615c6a97] response.statistics:QueryStatistics{creationTime=1721186342087, endTime=1721186344621, startTime=1721186342699, numChildJobs=null, parentJobId=null, scriptStatistics=null, reservationUsage=null, transactionInfo=null, sessionInfo=null, biEngineStats=null, billingTier=1, cacheHit=false, totalBytesBilled=20971520, totalBytesProcessed=464, queryPlan=[QueryStage{completedParallelInputs=1, computeMsAvg=6, computeMsMax=6, computeRatioAvg=0.027906976744186046, computeRatioMax=0.027906976744186046, endMs=1721186343007, generatedId=0, inputStages=null, name=S00: Input, parallelInputs=1, readMsAvg=28, readMsMax=28, readRatioAvg=0.13023255813953488, readRatioMax=0.13023255813953488, recordsRead=6, recordsWritten=6, shuffleOutputBytes=252, shuffleOutputBytesSpilled=0, startMs=1721186342941, status=COMPLETE, steps=[QueryStep{name=READ, substeps=[$10:key_long, $11:key_string, $12:$file_temp_id, $13:$row_temp_id, FROM test_by_sano.output]}, QueryStep{name=COMPUTE, substeps=[$150 := 1]}, QueryStep{name=WRITE, substeps=[$10, $11, $12, $13, $150, TO __stage00_output]}], waitMsAvg=1, waitMsMax=1, waitRatioAvg=0.004651162790697674, waitRatioMax=0.004651162790697674, writeMsAvg=5, writeMsMax=5, writeRatioAvg=0.023255813953488372, writeRatioMax=0.023255813953488372, slotMs=102}, QueryStage{completedParallelInputs=100, computeMsAvg=9, computeMsMax=14, computeRatioAvg=0.04186046511627907, computeRatioMax=0.06511627906976744, endMs=1721186343110, generatedId=1, inputStages=[0], name=S01: Coalesce, parallelInputs=100, readMsAvg=0, readMsMax=0, readRatioAvg=0.0, readRatioMax=0.0, recordsRead=6, recordsWritten=6, shuffleOutputBytes=252, shuffleOutputBytesSpilled=0, startMs=1721186343043, status=COMPLETE, steps=[QueryStep{name=READ, substeps=[FROM __stage00_output]}], waitMsAvg=33, waitMsMax=36, waitRatioAvg=0.15348837209302327, waitRatioMax=0.16744186046511628, writeMsAvg=16, writeMsMax=52, writeRatioAvg=0.07441860465116279, writeRatioMax=0.24186046511627907, slotMs=8653}, QueryStage{completedParallelInputs=1, computeMsAvg=10, computeMsMax=10, computeRatioAvg=0.046511627906976744, computeRatioMax=0.046511627906976744, endMs=1721186343121, generatedId=2, inputStages=[1], name=S02: Join+, parallelInputs=1, readMsAvg=3, readMsMax=3, readRatioAvg=0.013953488372093023, readRatioMax=0.013953488372093023, recordsRead=12, recordsWritten=6, shuffleOutputBytes=666, shuffleOutputBytesSpilled=0, startMs=1721186343056, status=COMPLETE, steps=[QueryStep{name=READ, substeps=[$1:key_long, $2:key_string, $3:test_boolean, $4:test_long, $5:test_double, $6:test_string, $7:test_timestamp, $8:test_json, FROM test_by_sano.LOAD_TEMP_767ab041_eca5_4589_9377_8c4696e1cfc1_output]}, QueryStep{name=READ, substeps=[$10, $11, $12, $13, $150, FROM __stage01_output]}, QueryStep{name=AGGREGATE, substeps=[GROUP BY $180 := $101, $181 := $102, $182 := $90, $70 := ANY_AND_CHECK_FOR_UPDATE($121), $71 := ANY_AND_CHECK_FOR_UPDATE($120), $72 := ANY_AND_CHECK_FOR_UPDATE($122), $73 := ANY_AND_CHECK_FOR_UPDATE($123), $74 := ANY_AND_CHECK_FOR_UPDATE($124), $75 := ANY_AND_CHECK_FOR_UPDATE($125), $76 := ANY_AND_CHECK_FOR_UPDATE($126), $77 := ANY_AND_CHECK_FOR_UPDATE($127), $78 := ANY_AND_CHECK_FOR_UPDATE($128), $79 := ANY_AND_CHECK_FOR_UPDATE($129), $80 := ANY_AND_CHECK_FOR_UPDATE($141), $81 := ANY_AND_CHECK_FOR_UPDATE($142), $82 := ANY_AND_CHECK_FOR_UPDATE($143), $83 := ANY_AND_CHECK_FOR_UPDATE($144), $84 := ANY_AND_CHECK_FOR_UPDATE($145), $85 := ANY_AND_CHECK_FOR_UPDATE($146)]}, QueryStep{name=COMPUTE, substeps=[$90 := if(equal($120, 10001), $100, NULL)]}, QueryStep{name=COMPUTE, substeps=[$100 := UNIQUE_ROW_ID(), $101 := if(equal($120, 10001), SAFE_EXPR(CAST(add(1000000000, abs(mod(farm_fingerprint($110), 1000000000))) AS UINT64)), $160), $102 := if(equal($120, 10001), 18446744073709551615, $161)]}, QueryStep{name=COMPUTE, substeps=[$110 := UNIQUE_ROW_ID()]}, QueryStep{name=FILTER, substeps=[not(equal($120, 0))]}, QueryStep{name=COMPUTE, substeps=[$120 := if($130, 10001, $140), $121 := if($130, 2, if(not(is_null($162)), 1, -1)), $122 := if($130, $163, NULL), $123 := if($130, $164, NULL), $124 := if($130, $165, NULL), $125 := if($130, $166, NULL), $126 := if($130, $167, NULL), $127 := if($130, $168, NULL), $128 := if($130, $169, NULL), $129 := if($130, $170, NULL)]}, QueryStep{name=COMPUTE, substeps=[$130 := and(equal($140, 0), is_null($162))]}, QueryStep{name=COMPUTE, substeps=[$140 := if(not(is_null($162)), 10002, 0), $141 := if(not(is_null($162)), $163, NULL), $142 := if(not(is_null($162)), $164, NULL), $143 := if(not(is_null($162)), $165, NULL), $144 := if(not(is_null($162)), $166, NULL), $145 := if(not(is_null($162)), $167, NULL), $146 := if(not(is_null($162)), $168, NULL), $147 := if(not(is_null($162)), $169, NULL), $148 := if(not(is_null($162)), $170, NULL)]}, QueryStep{name=JOIN, substeps=[$163 := $1, $164 := $2, $165 := $3, $166 := $4, $167 := $5, $168 := $6, $169 := $7, $170 := $8, $160 := $12, $161 := $13, $162 := $150, LEFT OUTER HASH JOIN EACH  WITH ALL  ON $1 = $10, $2 = $11]}, QueryStep{name=WRITE, substeps=[$70, $71, $72, $73, $74, $75, $76, $77, $78, $79, $80, $81, $82, $83, $84, $85, TO __stage02_output, BY HASH($180, $181, $182)]}], waitMsAvg=46, waitMsMax=46, waitRatioAvg=0.21395348837209302, waitRatioMax=0.21395348837209302, writeMsAvg=2, writeMsMax=2, writeRatioAvg=0.009302325581395349, writeRatioMax=0.009302325581395349, slotMs=20}, QueryStage{completedParallelInputs=1, computeMsAvg=8, computeMsMax=8, computeRatioAvg=0.037209302325581395, computeRatioMax=0.037209302325581395, endMs=1721186343189, generatedId=3, inputStages=[2], name=S03: Aggregate, parallelInputs=1, readMsAvg=0, readMsMax=0, readRatioAvg=0.0, readRatioMax=0.0, recordsRead=6, recordsWritten=6, shuffleOutputBytes=570, shuffleOutputBytesSpilled=0, startMs=1721186343131, status=COMPLETE, steps=[QueryStep{name=READ, substeps=[$70, $71, $72, $73, $74, $75, $76, $77, $78, $79, $80, $81, $82, $83, $84, $85, FROM __stage02_output]}, QueryStep{name=AGGREGATE, substeps=[GROUP BY $190 := $180, $191 := $181, $192 := $182, $50 := ANY_AND_CHECK_FOR_UPDATE($70), $51 := ANY_AND_CHECK_FOR_UPDATE($71), $52 := ANY_AND_CHECK_FOR_UPDATE($72), $53 := ANY_AND_CHECK_FOR_UPDATE($73), $54 := ANY_AND_CHECK_FOR_UPDATE($74), $55 := ANY_AND_CHECK_FOR_UPDATE($75), $56 := ANY_AND_CHECK_FOR_UPDATE($76), $57 := ANY_AND_CHECK_FOR_UPDATE($77), $58 := ANY_AND_CHECK_FOR_UPDATE($78), $59 := ANY_AND_CHECK_FOR_UPDATE($79), $60 := ANY_AND_CHECK_FOR_UPDATE($80), $61 := ANY_AND_CHECK_FOR_UPDATE($81), $62 := ANY_AND_CHECK_FOR_UPDATE($82), $63 := ANY_AND_CHECK_FOR_UPDATE($83), $64 := ANY_AND_CHECK_FOR_UPDATE($84), $65 := ANY_AND_CHECK_FOR_UPDATE($85)]}, QueryStep{name=WRITE, substeps=[$50, $51, $52, $53, $54, $55, $56, $57, $58, $59, $60, $61, $62, $63, $64, $65, TO __stage03_output, BY HASH($190)]}], waitMsAvg=1, waitMsMax=1, waitRatioAvg=0.004651162790697674, waitRatioMax=0.004651162790697674, writeMsAvg=20, writeMsMax=20, writeRatioAvg=0.09302325581395349, writeRatioMax=0.09302325581395349, slotMs=129}, QueryStage{completedParallelInputs=1, computeMsAvg=13, computeMsMax=13, computeRatioAvg=0.06046511627906977, computeRatioMax=0.06046511627906977, endMs=1721186343252, generatedId=4, inputStages=[3], name=S04: Sort+, parallelInputs=1, readMsAvg=15, readMsMax=15, readRatioAvg=0.06976744186046512, readRatioMax=0.06976744186046512, recordsRead=12, recordsWritten=9, shuffleOutputBytes=487, shuffleOutputBytesSpilled=0, startMs=1721186343207, status=COMPLETE, steps=[QueryStep{name=READ, substeps=[$50, $51, $52, $53, $54, $55, $56, $57, $58, $59, $60, $61, $62, $63, $64, $65, FROM __stage03_output]}, QueryStep{name=COMPUTE, substeps=[$20 := if(equal(2, $30), $221, if(equal(1, $30), $229, $40)), $21 := if(equal(2, $30), $222, if(equal(1, $30), $230, $41)), $22 := if(equal(2, $30), $223, if(equal(1, $30), $231, $42)), $23 := if(equal(2, $30), $224, if(equal(1, $30), $232, $43)), $24 := if(equal(2, $30), $225, if(equal(1, $30), $233, $44)), $25 := if(equal(2, $30), $226, if(equal(1, $30), $234, $45)), $26 := if(equal(2, $30), $227, if(equal(1, $30), $235, $46)), $27 := if(equal(2, $30), $228, if(equal(1, $30), $236, $47)), $28 := if(equal(-1, $30), 'REINSERT', if(in($30, 1), 'UPDATE', NULL))]}, QueryStep{name=COMPUTE, substeps=[$30 := if(not($48), -1, $220)]}, QueryStep{name=SORT, substeps=[$190 ASC, $191 DESC]}, QueryStep{name=WRITE, substeps=[$20, $21, $22, $23, $24, $25, $26, $27, $28, TO __stage04_output]}], waitMsAvg=2, waitMsMax=2, waitRatioAvg=0.009302325581395349, waitRatioMax=0.009302325581395349, writeMsAvg=6, writeMsMax=6, writeRatioAvg=0.027906976744186046, writeRatioMax=0.027906976744186046, slotMs=68}, QueryStage{completedParallelInputs=50, computeMsAvg=9, computeMsMax=13, computeRatioAvg=0.04186046511627907, computeRatioMax=0.06046511627906977, endMs=1721186343338, generatedId=5, inputStages=[4], name=S05: Coalesce, parallelInputs=50, readMsAvg=0, readMsMax=0, readRatioAvg=0.0, readRatioMax=0.0, recordsRead=9, recordsWritten=9, shuffleOutputBytes=487, shuffleOutputBytesSpilled=0, startMs=1721186343261, status=COMPLETE, steps=[QueryStep{name=READ, substeps=[FROM __stage04_output]}], waitMsAvg=1, waitMsMax=2, waitRatioAvg=0.004651162790697674, waitRatioMax=0.009302325581395349, writeMsAvg=30, writeMsMax=54, writeRatioAvg=0.13953488372093023, writeRatioMax=0.25116279069767444, slotMs=5007}, QueryStage{completedParallelInputs=1, computeMsAvg=13, computeMsMax=13, computeRatioAvg=0.06046511627906977, computeRatioMax=0.06046511627906977, endMs=1721186343674, generatedId=6, inputStages=[5], name=S06: Output, parallelInputs=1, readMsAvg=0, readMsMax=0, readRatioAvg=0.0, readRatioMax=0.0, recordsRead=9, recordsWritten=9, shuffleOutputBytes=0, shuffleOutputBytesSpilled=0, startMs=1721186343448, status=COMPLETE, steps=[QueryStep{name=READ, substeps=[$20, $21, $22, $23, $24, $25, $26, $27, $28, FROM __stage05_output]}, QueryStep{name=WRITE, substeps=[$20, $21, $22, $23, $24, $25, $26, $27, TO __stage06_output]}], waitMsAvg=187, waitMsMax=187, waitRatioAvg=0.8697674418604651, waitRatioMax=0.8697674418604651, writeMsAvg=215, writeMsMax=215, writeRatioAvg=1.0, writeRatioMax=1.0, slotMs=243}], timeline=[TimelineSample{elapsedMs=742, activeUnits=0, completedUnits=154, pendingUnits=1, slotMillis=13983}, TimelineSample{elapsedMs=1243, activeUnits=0, completedUnits=155, pendingUnits=0, slotMillis=14226}], schema=null, queryParameters=null}
2024-07-17 03:19:13.383 +0000 [INFO] (0001:transaction): embulk-output-bigquery: Delete table... test_by_sano.LOAD_TEMP_767ab041_eca5_4589_9377_8c4696e1cfc1_output
2024-07-17 03:19:13.712 +0000 [INFO] (main): Committed.
2024-07-17 03:19:13.713 +0000 [INFO] (main): Next config diff: {"in":{"last_path":"test_2.jsonl"},"out":{}}

$ embulk run config_in.yml
2024-07-17 03:19:22.227 +0000: Embulk v0.9.26
2024-07-17 03:19:22.853 +0000 [WARN] (main): DEPRECATION: JRuby org.jruby.embed.ScriptingContainer is directly injected.
2024-07-17 03:19:24.181 +0000 [INFO] (main): Gem's home and path are set by default: "/home/ubuntu/.embulk/lib/gems"
2024-07-17 03:19:24.728 +0000 [INFO] (main): Started Embulk v0.9.26
WARNING: You are running Ruby 2.3.3, which is nearing end-of-life.
The Google Cloud API clients work best on supported versions of Ruby. Consider upgrading to Ruby 2.4 or later.
See https://www.ruby-lang.org/en/downloads/branches/ for more info on the Ruby maintenance schedule.
To suppress this message, set the GOOGLE_CLOUD_SUPPRESS_RUBY_WARNINGS environment variable.
2024-07-17 03:19:27.902 +0000 [INFO] (0001:transaction): Loaded plugin embulk-input-bigquery (0.1.0)
2024-07-17 03:19:27.931 +0000 [INFO] (0001:transaction): Loaded plugin embulk-output-command (0.1.4)
2024-07-17 03:19:28.552 +0000 [INFO] (0001:transaction): determine columns using the getQueryResults API instead of the config.yml
2024-07-17 03:19:29.540 +0000 [INFO] (0001:transaction): waiting for the query job to complete to get schema from query results
2024-07-17 03:19:29.541 +0000 [INFO] (0001:transaction): completed: job_id=job_eInMrUCiGbKVTJg6nhfn48lX0ibo
2024-07-17 03:19:31.154 +0000 [INFO] (0001:transaction): determined columns: [{"name"=>"key_long", "type"=>:long}, {"name"=>"key_string", "type"=>:string}, {"name"=>"test_boolean", "type"=>:boolean}, {"name"=>"test_long", "type"=>:long}, {"name"=>"test_double", "type"=>:double}, {"name"=>"test_string", "type"=>:string}, {"name"=>"test_timestamp", "type"=>:timestamp}, {"name"=>"test_json", "type"=>:string}]
2024-07-17 03:19:31.159 +0000 [INFO] (0001:transaction): Using local thread executor with max_threads=16 / output tasks 8 = input tasks 1 * 8
2024-07-17 03:19:31.187 +0000 [INFO] (0001:transaction): Loaded plugin embulk-formatter-jsonl (0.1.4)
2024-07-17 03:19:31.198 +0000 [INFO] (0001:transaction): {done:  0 / 1, running: 0}
2024-07-17 03:19:31.208 +0000 [INFO] (0023:task-0000): Using command [sh, -c, cat -]
2024-07-17 03:19:31.217 +0000 [INFO] (0023:task-0000): Using command [sh, -c, cat -]
2024-07-17 03:19:31.220 +0000 [INFO] (0023:task-0000): Using command [sh, -c, cat -]
2024-07-17 03:19:31.222 +0000 [INFO] (0023:task-0000): Using command [sh, -c, cat -]
2024-07-17 03:19:31.224 +0000 [INFO] (0023:task-0000): Using command [sh, -c, cat -]
2024-07-17 03:19:31.227 +0000 [INFO] (0023:task-0000): Using command [sh, -c, cat -]
2024-07-17 03:19:31.230 +0000 [INFO] (0023:task-0000): Using command [sh, -c, cat -]
2024-07-17 03:19:31.233 +0000 [INFO] (0023:task-0000): Using command [sh, -c, cat -]
{"key_long":1,"key_string":"a","test_boolean":true,"test_long":123,"test_double":1.23,"test_string":"あいうえお","test_timestamp":"1999-12-31 23:59:59 +0000","test_json":"{\"キー\":\"値\"}"}
{"key_long":2,"key_string":"b","test_boolean":false,"test_long":456,"test_double":4.56,"test_string":"かきくけこ","test_timestamp":"2000-01-01 00:00:00 +0000","test_json":"[{\"キー1\":\"値1\"},{\"キー2\":\"値2\"}]"}
{"key_long":3,"key_string":"c","test_boolean":false,"test_long":456,"test_double":4.56,"test_string":"かきくけこ","test_timestamp":"2000-01-01 00:00:00 +0000","test_json":"[{\"キー1\":\"値1\"},{\"キー2\":\"値2\"}]"}
{"key_long":4,"key_string":"d","test_boolean":null,"test_long":null,"test_double":null,"test_string":null,"test_timestamp":null,"test_json":"12345"}
{"key_long":5,"key_string":"e","test_boolean":null,"test_long":null,"test_double":null,"test_string":null,"test_timestamp":null,"test_json":null}
{"key_long":6,"key_string":"f","test_boolean":null,"test_long":null,"test_double":null,"test_string":null,"test_timestamp":null,"test_json":"\"hoge\""}
{"key_long":7,"key_string":"g","test_boolean":null,"test_long":null,"test_double":null,"test_string":null,"test_timestamp":null,"test_json":"12345"}
{"key_long":8,"key_string":"h","test_boolean":null,"test_long":null,"test_double":null,"test_string":null,"test_timestamp":null,"test_json":"123.45"}
{"key_long":9,"key_string":"i","test_boolean":null,"test_long":null,"test_double":null,"test_string":null,"test_timestamp":null,"test_json":"\"hoge\""}
2024-07-17 03:19:32.877 +0000 [INFO] (0001:transaction): {done:  1 / 1, running: 0}
2024-07-17 03:19:32.882 +0000 [INFO] (main): Committed.
2024-07-17 03:19:32.883 +0000 [INFO] (main): Next config diff: {"in":{},"out":{}}
```

</details>