### PR TITLE
enable spotless googleJavaFormat

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -92,6 +92,6 @@ spotless {
     java {
         importOrder()
         removeUnusedImports()
-        // googleJavaFormat()
+        googleJavaFormat()
     }
 }

--- a/src/main/java/org/embulk/output/bigquery_java/BigqueryClient.java
+++ b/src/main/java/org/embulk/output/bigquery_java/BigqueryClient.java
@@ -27,6 +27,22 @@ import com.google.cloud.bigquery.TableInfo;
 import com.google.cloud.bigquery.TableResult;
 import com.google.cloud.bigquery.TimePartitioning;
 import com.google.cloud.bigquery.WriteChannelConfiguration;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.channels.Channels;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.Spliterator;
+import java.util.Spliterators;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 import org.embulk.output.bigquery_java.config.BigqueryColumnOption;
 import org.embulk.output.bigquery_java.config.BigqueryTimePartitioning;
 import org.embulk.output.bigquery_java.config.PluginTask;
@@ -49,646 +65,686 @@ import org.embulk.util.retryhelper.Retryable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.OutputStream;
-import java.nio.channels.Channels;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
-import java.util.Spliterator;
-import java.util.Spliterators;
-import java.util.UUID;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-import java.util.stream.StreamSupport;
-
 public class BigqueryClient {
-    private final Logger logger = LoggerFactory.getLogger(BigqueryClient.class);
-    private BigQuery bigquery;
-    private String dataset;
-    private String location;
-    private String locationForLog;
-    private PluginTask task;
-    private Schema schema;
-    private List<BigqueryColumnOption> columnOptions;
+  private final Logger logger = LoggerFactory.getLogger(BigqueryClient.class);
+  private BigQuery bigquery;
+  private String dataset;
+  private String location;
+  private String locationForLog;
+  private PluginTask task;
+  private Schema schema;
+  private List<BigqueryColumnOption> columnOptions;
 
-    public BigqueryClient(PluginTask task, Schema schema) {
-        this.task = task;
-        this.schema = schema;
-        this.dataset = task.getDataset();
-        if (task.getLocation().isPresent()){
-            this.location = task.getLocation().get();
-            this.locationForLog = task.getLocation().get();
-        }else{
-            this.locationForLog = "us/eu";
-        }
-        this.columnOptions = this.task.getColumnOptions().orElse(Collections.emptyList());
-        try {
-            this.bigquery = getClientWithJsonKey(this.task.getJsonKeyfile());
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
+  public BigqueryClient(PluginTask task, Schema schema) {
+    this.task = task;
+    this.schema = schema;
+    this.dataset = task.getDataset();
+    if (task.getLocation().isPresent()) {
+      this.location = task.getLocation().get();
+      this.locationForLog = task.getLocation().get();
+    } else {
+      this.locationForLog = "us/eu";
+    }
+    this.columnOptions = this.task.getColumnOptions().orElse(Collections.emptyList());
+    try {
+      this.bigquery = getClientWithJsonKey(this.task.getJsonKeyfile());
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private static BigQuery getClientWithJsonKey(String key) throws IOException {
+    return BigQueryOptions.newBuilder()
+        .setCredentials(ServiceAccountCredentials.fromStream(new FileInputStream(key)))
+        .build()
+        .getService();
+  }
+
+  public Dataset createDataset(String datasetId) {
+    DatasetInfo.Builder builder = DatasetInfo.newBuilder(datasetId);
+    if (this.location != null) {
+      builder.setLocation(this.location);
+    }
+    return bigquery.create(builder.build());
+  }
+
+  public Dataset getDataset(String datasetId) {
+    return bigquery.getDataset(datasetId);
+  }
+
+  public Job getJob(JobId jobId) {
+    return this.bigquery.getJob(jobId);
+  }
+
+  public Table getTable(String name) {
+    return getTable(TableId.of(this.dataset, name));
+  }
+
+  public Table getTable(TableId tableId) {
+    return this.bigquery.getTable(tableId);
+  }
+
+  public void createTableIfNotExist(String table) {
+    createTableIfNotExist(table, dataset);
+  }
+
+  public void createTableIfNotExist(String table, String dataset) {
+    com.google.cloud.bigquery.Schema schema = buildSchema(this.schema, this.columnOptions);
+    StandardTableDefinition.Builder tableDefinitionBuilder = StandardTableDefinition.newBuilder();
+    tableDefinitionBuilder.setSchema(schema);
+    if (this.task.getTimePartitioning().isPresent()) {
+      tableDefinitionBuilder.setTimePartitioning(
+          buildTimePartitioning(this.task.getTimePartitioning().get()));
+    }
+    if (this.task.getClustering().isPresent()) {
+      tableDefinitionBuilder.setClustering(
+          Clustering.newBuilder()
+              .setFields(this.task.getClustering().get().getFields().get())
+              .build());
+    }
+    TableDefinition tableDefinition = tableDefinitionBuilder.build();
+
+    try {
+      bigquery.create(TableInfo.newBuilder(TableId.of(dataset, table), tableDefinition).build());
+    } catch (BigQueryException e) {
+      if (e.getCode() == 409 && e.getMessage().contains("Already Exists:")) {
+        return;
+      }
+      logger.error(String.format("embulk-out_bigquery: insert_table(%s, %s)", dataset, table));
+      throw new BigqueryException(
+          String.format("failed to create table %s.%s, response: %s", dataset, table, e));
+    }
+  }
+
+  public TimePartitioning buildTimePartitioning(BigqueryTimePartitioning bigqueryTimePartitioning) {
+    TimePartitioning.Builder timePartitioningBuilder;
+
+    switch (bigqueryTimePartitioning.getType().toUpperCase()) {
+      case "HOUR":
+        timePartitioningBuilder = TimePartitioning.newBuilder(TimePartitioning.Type.HOUR);
+        break;
+      case "DAY":
+        timePartitioningBuilder = TimePartitioning.newBuilder(TimePartitioning.Type.DAY);
+        break;
+      case "MONTH":
+        timePartitioningBuilder = TimePartitioning.newBuilder(TimePartitioning.Type.MONTH);
+        break;
+      case "YEAR":
+        timePartitioningBuilder = TimePartitioning.newBuilder(TimePartitioning.Type.YEAR);
+        break;
+      default:
+        throw new RuntimeException("time_partitioning.type is not HOUR, DAY, MONTH, or YEAR");
     }
 
-    private static BigQuery getClientWithJsonKey(String key) throws IOException {
-        return BigQueryOptions.newBuilder()
-                .setCredentials(ServiceAccountCredentials.fromStream(new FileInputStream(key)))
-                .build()
-                .getService();
+    if (bigqueryTimePartitioning.getExpirationMs().isPresent()) {
+      timePartitioningBuilder.setExpirationMs(bigqueryTimePartitioning.getExpirationMs().get());
     }
 
-    public Dataset createDataset(String datasetId){
-        DatasetInfo.Builder builder = DatasetInfo.newBuilder(datasetId);
-        if (this.location != null){
-            builder.setLocation(this.location);
-        }
-        return bigquery.create(builder.build());
+    if (bigqueryTimePartitioning.getField().isPresent()) {
+      timePartitioningBuilder.setField(bigqueryTimePartitioning.getField().get());
     }
+    return timePartitioningBuilder.build();
+  }
 
-    public Dataset getDataset(String datasetId) {
-        return bigquery.getDataset(datasetId);
-    }
+  public JobStatistics.LoadStatistics load(
+      Path loadFile, String table, JobInfo.WriteDisposition writeDisposition)
+      throws BigqueryException {
+    String dataset = this.dataset;
+    int retries = this.task.getRetries();
+    PluginTask task = this.task;
+    Schema schema = this.schema;
+    List<BigqueryColumnOption> columnOptions = this.columnOptions;
 
-    public Job getJob(JobId jobId) {
-        return this.bigquery.getJob(jobId);
-    }
+    try {
+      // https://cloud.google.com/bigquery/quotas#standard_tables
+      // Maximum rate of table metadata update operations — 5 operations every 10 seconds per table
+      return RetryExecutor.builder()
+          .withRetryLimit(retries)
+          .withInitialRetryWaitMillis(2 * 1000)
+          .withMaxRetryWaitMillis(10 * 1000)
+          .build()
+          .runInterruptible(
+              new Retryable<JobStatistics.LoadStatistics>() {
+                @Override
+                public JobStatistics.LoadStatistics call() {
+                  UUID uuid = UUID.randomUUID();
+                  String jobId = String.format("embulk_load_job_%s", uuid.toString());
 
-    public Table getTable(String name) {
-        return getTable(TableId.of(this.dataset, name));
-    }
+                  if (Files.exists(loadFile)) {
+                    logger.info(
+                        "embulk-output-bigquery: Load job starting... job_id:[{}] {} => {}.{} in {}",
+                        jobId,
+                        loadFile.toString(),
+                        dataset,
+                        table,
+                        locationForLog);
+                  } else {
+                    logger.info(
+                        "embulk-output-bigquery: Load job starting... {} does not exist, skipped",
+                        loadFile.toString());
+                    // TODO: should throw error?
+                    return null;
+                  }
 
-    public Table getTable(TableId tableId) {
-        return this.bigquery.getTable(tableId);
-    }
+                  TableId tableId = TableId.of(dataset, table);
+                  WriteChannelConfiguration writeChannelConfiguration =
+                      WriteChannelConfiguration.newBuilder(tableId)
+                          .setFormatOptions(FormatOptions.json())
+                          .setWriteDisposition(writeDisposition)
+                          .setMaxBadRecords(task.getMaxBadRecords())
+                          .setIgnoreUnknownValues(task.getIgnoreUnknownValues())
+                          .setSchema(buildSchema(schema, columnOptions))
+                          .build();
+                  TableDataWriteChannel writer =
+                      bigquery.writer(JobId.of(jobId), writeChannelConfiguration);
 
-    public void  createTableIfNotExist(String table) {
-        createTableIfNotExist(table, dataset);
-    }
+                  try (OutputStream stream = Channels.newOutputStream(writer)) {
+                    Files.copy(loadFile, stream);
+                  } catch (IOException e) {
+                    logger.info(e.getMessage());
+                  }
 
-    public void createTableIfNotExist(String table, String dataset) {
-        com.google.cloud.bigquery.Schema schema = buildSchema(this.schema, this.columnOptions);
-        StandardTableDefinition.Builder tableDefinitionBuilder = StandardTableDefinition.newBuilder();
-        tableDefinitionBuilder.setSchema(schema);
-        if (this.task.getTimePartitioning().isPresent()) {
-            tableDefinitionBuilder.setTimePartitioning(buildTimePartitioning(this.task.getTimePartitioning().get()));
-        }
-        if (this.task.getClustering().isPresent()){
-            tableDefinitionBuilder.setClustering(
-                    Clustering.newBuilder().setFields(this.task.getClustering().get().getFields().get()).build()
-            );
-        }
-        TableDefinition tableDefinition = tableDefinitionBuilder.build();
-
-        try{
-            bigquery.create(TableInfo.newBuilder(TableId.of(dataset, table), tableDefinition).build());
-        }catch (BigQueryException e){
-            if(e.getCode() == 409 && e.getMessage().contains("Already Exists:")){
-                return;
-            }
-            logger.error(String.format("embulk-out_bigquery: insert_table(%s, %s)", dataset, table));
-            throw new BigqueryException(String.format("failed to create table %s.%s, response: %s", dataset, table, e));
-        }
-    }
-
-    public TimePartitioning buildTimePartitioning(BigqueryTimePartitioning bigqueryTimePartitioning) {
-        TimePartitioning.Builder timePartitioningBuilder;
-
-        switch (bigqueryTimePartitioning.getType().toUpperCase()) {
-            case "HOUR":
-                timePartitioningBuilder = TimePartitioning.newBuilder(TimePartitioning.Type.HOUR);
-                break;
-            case "DAY":
-                timePartitioningBuilder = TimePartitioning.newBuilder(TimePartitioning.Type.DAY);
-                break;
-            case "MONTH":
-                timePartitioningBuilder = TimePartitioning.newBuilder(TimePartitioning.Type.MONTH);
-                break;
-            case "YEAR":
-                timePartitioningBuilder = TimePartitioning.newBuilder(TimePartitioning.Type.YEAR);
-                break;
-            default:
-                throw new RuntimeException("time_partitioning.type is not HOUR, DAY, MONTH, or YEAR");
-        }
-
-        if (bigqueryTimePartitioning.getExpirationMs().isPresent()) {
-            timePartitioningBuilder.setExpirationMs(bigqueryTimePartitioning.getExpirationMs().get());
-        }
-
-        if (bigqueryTimePartitioning.getField().isPresent()) {
-            timePartitioningBuilder.setField(bigqueryTimePartitioning.getField().get());
-        }
-        return timePartitioningBuilder.build();
-    }
-
-    public JobStatistics.LoadStatistics load(Path loadFile, String table, JobInfo.WriteDisposition writeDisposition) throws BigqueryException {
-        String dataset = this.dataset;
-        int retries = this.task.getRetries();
-        PluginTask task = this.task;
-        Schema schema = this.schema;
-        List<BigqueryColumnOption> columnOptions = this.columnOptions;
-
-        try {
-            // https://cloud.google.com/bigquery/quotas#standard_tables
-            // Maximum rate of table metadata update operations — 5 operations every 10 seconds per table
-            return RetryExecutor.builder()
-                    .withRetryLimit(retries)
-                    .withInitialRetryWaitMillis(2 * 1000)
-                    .withMaxRetryWaitMillis(10 * 1000)
-                    .build()
-                    .runInterruptible(new Retryable<JobStatistics.LoadStatistics>() {
-                        @Override
-                        public JobStatistics.LoadStatistics call() {
-                            UUID uuid = UUID.randomUUID();
-                            String jobId = String.format("embulk_load_job_%s", uuid.toString());
-
-                            if (Files.exists(loadFile)) {
-                                logger.info("embulk-output-bigquery: Load job starting... job_id:[{}] {} => {}.{} in {}",
-                                        jobId, loadFile.toString(), dataset, table, locationForLog);
-                            } else {
-                                logger.info("embulk-output-bigquery: Load job starting... {} does not exist, skipped", loadFile.toString());
-                                // TODO: should throw error?
-                                return null;
-                            }
-
-                            TableId tableId = TableId.of(dataset, table);
-                            WriteChannelConfiguration writeChannelConfiguration =
-                                    WriteChannelConfiguration.newBuilder(tableId)
-                                            .setFormatOptions(FormatOptions.json())
-                                            .setWriteDisposition(writeDisposition)
-                                            .setMaxBadRecords(task.getMaxBadRecords())
-                                            .setIgnoreUnknownValues(task.getIgnoreUnknownValues())
-                                            .setSchema(buildSchema(schema, columnOptions))
-                                            .build();
-                            TableDataWriteChannel writer = bigquery.writer(JobId.of(jobId), writeChannelConfiguration);
-
-                            try (OutputStream stream = Channels.newOutputStream(writer)) {
-                                Files.copy(loadFile, stream);
-                            } catch (IOException e) {
-                                logger.info(e.getMessage());
-                            }
-
-                            Job job = writer.getJob();
-                            return (JobStatistics.LoadStatistics) waitForLoad(job);
-                        }
-
-                        @Override
-                        public boolean isRetryableException(Exception exception) {
-                            return exception instanceof BigqueryBackendException
-                                    || exception instanceof BigqueryRateLimitExceededException
-                                    || exception instanceof BigqueryInternalException;
-                        }
-
-                        @Override
-                        public void onRetry(Exception exception, int retryCount, int retryLimit, int retryWait)
-                                throws RetryGiveupException {
-                            String message = String.format("embulk-output-bigquery: Load job failed. Retrying %d/%d after %d seconds. Message: %s",
-                                    retryCount, retryLimit, retryWait / 1000, exception.getMessage());
-                            if (retryCount % retries == 0) {
-                                logger.warn(message, exception);
-                            } else {
-                                logger.warn(message);
-                            }
-                        }
-
-                        @Override
-                        public void onGiveup(Exception firstException, Exception lastException) throws RetryGiveupException {
-                            logger.error("embulk-output-bigquery: Give up retrying for Load job");
-                        }
-                    });
-
-        } catch (RetryGiveupException ex) {
-            if (ex.getCause() instanceof BigqueryException) {
-                throw (BigqueryException) ex.getCause();
-            }
-            // TODO:
-            throw new RuntimeException(ex);
-        } catch (InterruptedException ex) {
-            throw new BigqueryException("interrupted");
-        }
-    }
-
-    public JobStatistics.CopyStatistics copy(String sourceTable,
-                                             String destinationTable,
-                                             String destinationDataset,
-                                             JobInfo.WriteDisposition writeDisposition) throws BigqueryException {
-        String dataset = this.dataset;
-        int retries = this.task.getRetries();
-
-        try {
-            return RetryExecutor.builder()
-                    .withRetryLimit(retries)
-                    .withInitialRetryWaitMillis(2 * 1000)
-                    .withMaxRetryWaitMillis(10 * 1000)
-                    .build()
-                    .runInterruptible(new Retryable<JobStatistics.CopyStatistics>() {
-                        @Override
-                        public JobStatistics.CopyStatistics call() {
-                            UUID uuid = UUID.randomUUID();
-                            String jobId = String.format("embulk_load_job_%s", uuid.toString());
-                            TableId destTableId = TableId.of(destinationDataset, destinationTable);
-                            TableId srcTableId = TableId.of(dataset, sourceTable);
-
-                            CopyJobConfiguration copyJobConfiguration = CopyJobConfiguration.newBuilder(destTableId, srcTableId)
-                                    .setWriteDisposition(writeDisposition)
-                                    .build();
-
-                            Job job = bigquery.create(JobInfo.newBuilder(copyJobConfiguration).setJobId(JobId.of(jobId)).build());
-                            return (JobStatistics.CopyStatistics) waitForCopy(job);
-                        }
-
-                        @Override
-                        public boolean isRetryableException(Exception exception) {
-                            return exception instanceof BigqueryBackendException
-                                    || exception instanceof BigqueryRateLimitExceededException
-                                    || exception instanceof BigqueryInternalException;
-                        }
-
-                        @Override
-                        public void onRetry(Exception exception, int retryCount, int retryLimit, int retryWait)
-                                throws RetryGiveupException {
-                            String message = String.format("embulk-output-bigquery: Copy job failed. Retrying %d/%d after %d seconds. Message: %s",
-                                    retryCount, retryLimit, retryWait / 1000, exception.getMessage());
-                            if (retryCount % retries == 0) {
-                                logger.warn(message, exception);
-                            } else {
-                                logger.warn(message);
-                            }
-                        }
-
-                        @Override
-                        public void onGiveup(Exception firstException, Exception lastException) throws RetryGiveupException {
-                            logger.error("embulk-output-bigquery: Give up retrying for Copy job");
-                        }
-                    });
-
-        } catch (RetryGiveupException ex) {
-            if (ex.getCause() instanceof BigqueryException) {
-                throw (BigqueryException) ex.getCause();
-            }
-            // TODO:
-            throw new RuntimeException(ex);
-        } catch (InterruptedException ex) {
-            throw new BigqueryException("interrupted");
-        }
-    }
-
-    public JobStatistics.QueryStatistics merge(String sourceTable, String targetTable, List<String> mergeKeys, List<String> mergeRule) {
-        StringBuilder sb = new StringBuilder();
-        sb.append("MERGE ");
-        sb.append(quoteIdentifier(dataset));
-        sb.append(".");
-        sb.append(quoteIdentifier(targetTable));
-        sb.append(" T");
-        sb.append(" USING ");
-        sb.append(quoteIdentifier(dataset));
-        sb.append(".");
-        sb.append(quoteIdentifier(sourceTable));
-        sb.append(" S");
-        sb.append(" ON ");
-        appendMergeKeys(sb, mergeKeys.isEmpty() ? getMergeKeys(targetTable) : mergeKeys);
-        sb.append(" WHEN MATCHED THEN");
-        sb.append(" UPDATE SET ");
-        appendMergeRule(sb, mergeRule, schema);
-        sb.append(" WHEN NOT MATCHED THEN");
-        sb.append(" INSERT (");
-        appendColumns(sb, schema);
-        sb.append(") VALUES (");
-        appendColumns(sb, schema);
-        sb.append(")");
-        String query = sb.toString();
-        logger.info(String.format("embulk-output-bigquery: Execute query... %s", query));
-        return executeQuery(query);
-    }
-
-    private List<String> getMergeKeys(String table) {
-        String query =
-                "SELECT" +
-                " KCU.COLUMN_NAME " +
-                "FROM " +
-                quoteIdentifier(dataset) + ".INFORMATION_SCHEMA.KEY_COLUMN_USAGE KCU " +
-                "JOIN " +
-                quoteIdentifier(dataset) + ".INFORMATION_SCHEMA.TABLE_CONSTRAINTS TC " +
-                "ON" +
-                " KCU.CONSTRAINT_CATALOG = TC.CONSTRAINT_CATALOG AND" +
-                " KCU.CONSTRAINT_SCHEMA = TC.CONSTRAINT_SCHEMA AND" +
-                " KCU.CONSTRAINT_NAME = TC.CONSTRAINT_NAME AND" +
-                " KCU.TABLE_CATALOG = TC.TABLE_CATALOG AND" +
-                " KCU.TABLE_SCHEMA = TC.TABLE_SCHEMA AND" +
-                " KCU.TABLE_NAME = TC.TABLE_NAME " +
-                "WHERE" +
-                " TC.TABLE_NAME = '" + table + "' AND" +
-                " TC.CONSTRAINT_TYPE = 'PRIMARY KEY' " +
-                "ORDER BY" +
-                " KCU.ORDINAL_POSITION";
-        return stream(runQuery(query).iterateAll())
-                .flatMap(BigqueryClient::stream)
-                .map(FieldValue::getStringValue)
-                .collect(Collectors.toList());
-    }
-
-    public TableResult runQuery(String query) {
-        int retries = task.getRetries();
-        try {
-            return RetryExecutor.builder()
-                    .withRetryLimit(retries)
-                    .withInitialRetryWaitMillis(2 * 1000)
-                    .withMaxRetryWaitMillis(10 * 1000)
-                    .build()
-                    .runInterruptible(new Retryable<TableResult>() {
-                        @Override
-                        public TableResult call() throws Exception {
-                            QueryJobConfiguration configuration =
-                                    QueryJobConfiguration.newBuilder(query)
-                                            .setUseLegacySql(false)
-                                            .build();
-                            String job = String.format("embulk_query_job_%s", UUID.randomUUID());
-                            JobId.Builder builder = JobId.newBuilder().setJob(job);
-                            if (location != null){
-                                builder.setLocation(location);
-                            }
-                            return bigquery.query(configuration, builder.build());
-                        }
-                        @Override
-                        public boolean isRetryableException(Exception exception) {
-                            return exception instanceof BigqueryBackendException
-                                    || exception instanceof BigqueryRateLimitExceededException
-                                    || exception instanceof BigqueryInternalException;
-                        }
-                        @Override
-                        public void onRetry(Exception exception, int retryCount, int retryLimit, int retryWait) {
-                            String message = String.format("embulk-output-bigquery: Query job failed. Retrying %d/%d after %d seconds. Message: %s",
-                                    retryCount, retryLimit, retryWait / 1000, exception.getMessage());
-                            if (retryCount % retries == 0) {
-                                logger.warn(message, exception);
-                            } else {
-                                logger.warn(message);
-                            }
-                        }
-                        @Override
-                        public void onGiveup(Exception firstException, Exception lastException) {
-                            logger.error("embulk-output-bigquery: Give up retrying for Query job");
-                        }
-                    });
-        } catch (RetryGiveupException e) {
-            if (e.getCause() instanceof BigqueryException) {
-                throw (BigqueryException) e.getCause();
-            }
-            throw new RuntimeException(e);
-        } catch (InterruptedException e) {
-            throw new BigqueryException("interrupted");
-        }
-    }
-
-    private static <T> Stream<T> stream(Iterable<T> iterable) {
-        return StreamSupport.stream(Spliterators.spliteratorUnknownSize(iterable.iterator(), Spliterator.ORDERED), false);
-    }
-
-    private static StringBuilder appendMergeKeys(StringBuilder sb, List<String> mergeKeys) {
-        if (mergeKeys.isEmpty()) {
-            throw new RuntimeException("merge key or primary key is required");
-        }
-        for (int i = 0; i < mergeKeys.size(); i++) {
-            if (i != 0) { sb.append(" AND "); }
-            String mergeKey = quoteIdentifier(mergeKeys.get(i));
-            sb.append("T.");
-            sb.append(mergeKey);
-            sb.append(" = S.");
-            sb.append(mergeKey);
-        }
-        return sb;
-    }
-
-    private static StringBuilder appendMergeRule(StringBuilder sb, List<String> mergeRule, Schema schema) {
-        return mergeRule.isEmpty() ? appendMergeRule(sb, schema) : appendMergeRule(sb, mergeRule);
-    }
-
-    private static StringBuilder appendMergeRule(StringBuilder sb, List<String> mergeRule) {
-        for (int i = 0; i < mergeRule.size(); i++) {
-            if (i != 0) { sb.append(", "); }
-            sb.append(mergeRule.get(i));
-        }
-        return sb;
-    }
-
-    private static StringBuilder appendMergeRule(StringBuilder sb, Schema schema) {
-        for (int i = 0; i < schema.getColumnCount(); i++) {
-            if (i != 0) { sb.append(", "); }
-            String column = quoteIdentifier(schema.getColumnName(i));
-            sb.append("T.");
-            sb.append(column);
-            sb.append(" = S.");
-            sb.append(column);
-        }
-        return sb;
-    }
-
-    private static StringBuilder appendColumns(StringBuilder sb, Schema schema) {
-        for (int i = 0; i < schema.getColumnCount(); i++) {
-            if (i != 0) { sb.append(", "); }
-            sb.append(quoteIdentifier(schema.getColumnName(i)));
-        }
-        return sb;
-    }
-
-    private static String quoteIdentifier(String identifier) {
-        return "`" + identifier + "`";
-    }
-
-    public JobStatistics.QueryStatistics executeQuery(String query) {
-        int retries = this.task.getRetries();
-        String location = this.location;
-
-        try {
-            return RetryExecutor.builder()
-                    .withRetryLimit(retries)
-                    .withInitialRetryWaitMillis(2 * 1000)
-                    .withMaxRetryWaitMillis(10 * 1000)
-                    .build()
-                    .runInterruptible(new Retryable<JobStatistics.QueryStatistics>() {
-                        @Override
-                        public JobStatistics.QueryStatistics call() {
-                            UUID uuid = UUID.randomUUID();
-                            String jobId = String.format("embulk_query_job_%s", uuid.toString());
-
-                            QueryJobConfiguration queryConfig =
-                                    QueryJobConfiguration.newBuilder(query)
-                                            .setUseLegacySql(false)
-                                            .build();
-                            JobId.Builder jobIdBuilder = JobId.newBuilder().setJob(jobId);
-                            if (location != null){
-                                jobIdBuilder.setLocation(location);
-                            }
-
-                            Job job = bigquery.create(JobInfo.newBuilder(queryConfig).setJobId(jobIdBuilder.build()).build());
-                            return (JobStatistics.QueryStatistics) waitForQuery(job);
-                        }
-
-                        @Override
-                        public boolean isRetryableException(Exception exception) {
-                            return exception instanceof BigqueryBackendException
-                                    || exception instanceof BigqueryRateLimitExceededException
-                                    || exception instanceof BigqueryInternalException;
-                        }
-
-                        @Override
-                        public void onRetry(Exception exception, int retryCount, int retryLimit, int retryWait)
-                                throws RetryGiveupException {
-                            String message = String.format("embulk-output-bigquery: Query job failed. Retrying %d/%d after %d seconds. Message: %s",
-                                    retryCount, retryLimit, retryWait / 1000, exception.getMessage());
-                            if (retryCount % retries == 0) {
-                                logger.warn(message, exception);
-                            } else {
-                                logger.warn(message);
-                            }
-                        }
-
-                        @Override
-                        public void onGiveup(Exception firstException, Exception lastException) throws RetryGiveupException {
-                            logger.error("embulk-output-bigquery: Give up retrying for Query job");
-                        }
-                    });
-
-        } catch (RetryGiveupException ex) {
-            if (ex.getCause() instanceof BigqueryException) {
-                throw (BigqueryException) ex.getCause();
-            }
-            // TODO:
-            throw new RuntimeException(ex);
-        } catch (InterruptedException ex) {
-            throw new BigqueryException("interrupted");
-        }
-    }
-
-    public boolean deleteTable(String table) {
-        return deleteTable(table, null);
-    }
-
-    public boolean deleteTable(String table, String dataset) {
-        if (dataset == null){
-            dataset = this.dataset;
-        }
-        String chompedTable = BigqueryUtil.chompPartitionDecorator(table);
-        return deleteTableOrPartition(chompedTable, dataset);
-    }
-
-    public boolean deleteTableOrPartition(String table){
-        return deleteTableOrPartition(table, null);
-    }
-
-    //  if `table` with a partition decorator is given, a partition is deleted.
-    public boolean deleteTableOrPartition(String table, String dataset){
-        if (dataset == null){
-            dataset = this.dataset;
-        }
-        logger.info(String.format("embulk-output-bigquery: Delete table... %s.%s", dataset, table));
-        return this.bigquery.delete(TableId.of(dataset, table));
-    }
-
-    private JobStatistics waitForLoad(Job job) throws BigqueryException {
-        return new BigqueryJobWaiter(this.task, this, job).waitFor("Load");
-    }
-
-    private JobStatistics waitForCopy(Job job) throws BigqueryException {
-        return new BigqueryJobWaiter(this.task, this, job).waitFor("Copy");
-    }
-
-    private JobStatistics waitForQuery(Job job) throws BigqueryException {
-        return new BigqueryJobWaiter(this.task, this, job).waitFor("Query");
-    }
-
-    protected com.google.cloud.bigquery.Schema buildSchema(Schema schema, List<BigqueryColumnOption> columnOptions) {
-        // TODO: support schema file
-
-        if (this.task.getTemplateTable().isPresent()) {
-            TableId tableId = TableId.of(this.dataset, this.task.getTemplateTable().get());
-            Table table = this.bigquery.getTable(tableId);
-            return table.getDefinition().getSchema();
-        }
-
-        List<Field> fields = new ArrayList<>();
-
-        for (Column col : schema.getColumns()) {
-            Field.Mode fieldMode = Field.Mode.NULLABLE;
-            Optional<BigqueryColumnOption> columnOption = BigqueryUtil.findColumnOption(col.getName(), columnOptions);
-            Field.Builder fieldBuilder = createFieldBuilder(task, col, columnOption);
-
-            if (columnOption.isPresent()) {
-                BigqueryColumnOption colOpt = columnOption.get();
-                if (!colOpt.getMode().isEmpty()) {
-                    fieldMode = Field.Mode.valueOf(colOpt.getMode());
+                  Job job = writer.getJob();
+                  return (JobStatistics.LoadStatistics) waitForLoad(job);
                 }
-                fieldBuilder.setMode(fieldMode);
 
-                if (colOpt.getDescription().isPresent()) {
-                    fieldBuilder.setDescription(colOpt.getDescription().get());
+                @Override
+                public boolean isRetryableException(Exception exception) {
+                  return exception instanceof BigqueryBackendException
+                      || exception instanceof BigqueryRateLimitExceededException
+                      || exception instanceof BigqueryInternalException;
                 }
-            }
-            //  TODO:: support field for JSON type
-            Field field = fieldBuilder.build();
-            fields.add(field);
-        }
-        return com.google.cloud.bigquery.Schema.of(fields);
+
+                @Override
+                public void onRetry(
+                    Exception exception, int retryCount, int retryLimit, int retryWait)
+                    throws RetryGiveupException {
+                  String message =
+                      String.format(
+                          "embulk-output-bigquery: Load job failed. Retrying %d/%d after %d seconds. Message: %s",
+                          retryCount, retryLimit, retryWait / 1000, exception.getMessage());
+                  if (retryCount % retries == 0) {
+                    logger.warn(message, exception);
+                  } else {
+                    logger.warn(message);
+                  }
+                }
+
+                @Override
+                public void onGiveup(Exception firstException, Exception lastException)
+                    throws RetryGiveupException {
+                  logger.error("embulk-output-bigquery: Give up retrying for Load job");
+                }
+              });
+
+    } catch (RetryGiveupException ex) {
+      if (ex.getCause() instanceof BigqueryException) {
+        throw (BigqueryException) ex.getCause();
+      }
+      // TODO:
+      throw new RuntimeException(ex);
+    } catch (InterruptedException ex) {
+      throw new BigqueryException("interrupted");
+    }
+  }
+
+  public JobStatistics.CopyStatistics copy(
+      String sourceTable,
+      String destinationTable,
+      String destinationDataset,
+      JobInfo.WriteDisposition writeDisposition)
+      throws BigqueryException {
+    String dataset = this.dataset;
+    int retries = this.task.getRetries();
+
+    try {
+      return RetryExecutor.builder()
+          .withRetryLimit(retries)
+          .withInitialRetryWaitMillis(2 * 1000)
+          .withMaxRetryWaitMillis(10 * 1000)
+          .build()
+          .runInterruptible(
+              new Retryable<JobStatistics.CopyStatistics>() {
+                @Override
+                public JobStatistics.CopyStatistics call() {
+                  UUID uuid = UUID.randomUUID();
+                  String jobId = String.format("embulk_load_job_%s", uuid.toString());
+                  TableId destTableId = TableId.of(destinationDataset, destinationTable);
+                  TableId srcTableId = TableId.of(dataset, sourceTable);
+
+                  CopyJobConfiguration copyJobConfiguration =
+                      CopyJobConfiguration.newBuilder(destTableId, srcTableId)
+                          .setWriteDisposition(writeDisposition)
+                          .build();
+
+                  Job job =
+                      bigquery.create(
+                          JobInfo.newBuilder(copyJobConfiguration)
+                              .setJobId(JobId.of(jobId))
+                              .build());
+                  return (JobStatistics.CopyStatistics) waitForCopy(job);
+                }
+
+                @Override
+                public boolean isRetryableException(Exception exception) {
+                  return exception instanceof BigqueryBackendException
+                      || exception instanceof BigqueryRateLimitExceededException
+                      || exception instanceof BigqueryInternalException;
+                }
+
+                @Override
+                public void onRetry(
+                    Exception exception, int retryCount, int retryLimit, int retryWait)
+                    throws RetryGiveupException {
+                  String message =
+                      String.format(
+                          "embulk-output-bigquery: Copy job failed. Retrying %d/%d after %d seconds. Message: %s",
+                          retryCount, retryLimit, retryWait / 1000, exception.getMessage());
+                  if (retryCount % retries == 0) {
+                    logger.warn(message, exception);
+                  } else {
+                    logger.warn(message);
+                  }
+                }
+
+                @Override
+                public void onGiveup(Exception firstException, Exception lastException)
+                    throws RetryGiveupException {
+                  logger.error("embulk-output-bigquery: Give up retrying for Copy job");
+                }
+              });
+
+    } catch (RetryGiveupException ex) {
+      if (ex.getCause() instanceof BigqueryException) {
+        throw (BigqueryException) ex.getCause();
+      }
+      // TODO:
+      throw new RuntimeException(ex);
+    } catch (InterruptedException ex) {
+      throw new BigqueryException("interrupted");
+    }
+  }
+
+  public JobStatistics.QueryStatistics merge(
+      String sourceTable, String targetTable, List<String> mergeKeys, List<String> mergeRule) {
+    StringBuilder sb = new StringBuilder();
+    sb.append("MERGE ");
+    sb.append(quoteIdentifier(dataset));
+    sb.append(".");
+    sb.append(quoteIdentifier(targetTable));
+    sb.append(" T");
+    sb.append(" USING ");
+    sb.append(quoteIdentifier(dataset));
+    sb.append(".");
+    sb.append(quoteIdentifier(sourceTable));
+    sb.append(" S");
+    sb.append(" ON ");
+    appendMergeKeys(sb, mergeKeys.isEmpty() ? getMergeKeys(targetTable) : mergeKeys);
+    sb.append(" WHEN MATCHED THEN");
+    sb.append(" UPDATE SET ");
+    appendMergeRule(sb, mergeRule, schema);
+    sb.append(" WHEN NOT MATCHED THEN");
+    sb.append(" INSERT (");
+    appendColumns(sb, schema);
+    sb.append(") VALUES (");
+    appendColumns(sb, schema);
+    sb.append(")");
+    String query = sb.toString();
+    logger.info(String.format("embulk-output-bigquery: Execute query... %s", query));
+    return executeQuery(query);
+  }
+
+  private List<String> getMergeKeys(String table) {
+    String query =
+        "SELECT"
+            + " KCU.COLUMN_NAME "
+            + "FROM "
+            + quoteIdentifier(dataset)
+            + ".INFORMATION_SCHEMA.KEY_COLUMN_USAGE KCU "
+            + "JOIN "
+            + quoteIdentifier(dataset)
+            + ".INFORMATION_SCHEMA.TABLE_CONSTRAINTS TC "
+            + "ON"
+            + " KCU.CONSTRAINT_CATALOG = TC.CONSTRAINT_CATALOG AND"
+            + " KCU.CONSTRAINT_SCHEMA = TC.CONSTRAINT_SCHEMA AND"
+            + " KCU.CONSTRAINT_NAME = TC.CONSTRAINT_NAME AND"
+            + " KCU.TABLE_CATALOG = TC.TABLE_CATALOG AND"
+            + " KCU.TABLE_SCHEMA = TC.TABLE_SCHEMA AND"
+            + " KCU.TABLE_NAME = TC.TABLE_NAME "
+            + "WHERE"
+            + " TC.TABLE_NAME = '"
+            + table
+            + "' AND"
+            + " TC.CONSTRAINT_TYPE = 'PRIMARY KEY' "
+            + "ORDER BY"
+            + " KCU.ORDINAL_POSITION";
+    return stream(runQuery(query).iterateAll())
+        .flatMap(BigqueryClient::stream)
+        .map(FieldValue::getStringValue)
+        .collect(Collectors.toList());
+  }
+
+  public TableResult runQuery(String query) {
+    int retries = task.getRetries();
+    try {
+      return RetryExecutor.builder()
+          .withRetryLimit(retries)
+          .withInitialRetryWaitMillis(2 * 1000)
+          .withMaxRetryWaitMillis(10 * 1000)
+          .build()
+          .runInterruptible(
+              new Retryable<TableResult>() {
+                @Override
+                public TableResult call() throws Exception {
+                  QueryJobConfiguration configuration =
+                      QueryJobConfiguration.newBuilder(query).setUseLegacySql(false).build();
+                  String job = String.format("embulk_query_job_%s", UUID.randomUUID());
+                  JobId.Builder builder = JobId.newBuilder().setJob(job);
+                  if (location != null) {
+                    builder.setLocation(location);
+                  }
+                  return bigquery.query(configuration, builder.build());
+                }
+
+                @Override
+                public boolean isRetryableException(Exception exception) {
+                  return exception instanceof BigqueryBackendException
+                      || exception instanceof BigqueryRateLimitExceededException
+                      || exception instanceof BigqueryInternalException;
+                }
+
+                @Override
+                public void onRetry(
+                    Exception exception, int retryCount, int retryLimit, int retryWait) {
+                  String message =
+                      String.format(
+                          "embulk-output-bigquery: Query job failed. Retrying %d/%d after %d seconds. Message: %s",
+                          retryCount, retryLimit, retryWait / 1000, exception.getMessage());
+                  if (retryCount % retries == 0) {
+                    logger.warn(message, exception);
+                  } else {
+                    logger.warn(message);
+                  }
+                }
+
+                @Override
+                public void onGiveup(Exception firstException, Exception lastException) {
+                  logger.error("embulk-output-bigquery: Give up retrying for Query job");
+                }
+              });
+    } catch (RetryGiveupException e) {
+      if (e.getCause() instanceof BigqueryException) {
+        throw (BigqueryException) e.getCause();
+      }
+      throw new RuntimeException(e);
+    } catch (InterruptedException e) {
+      throw new BigqueryException("interrupted");
+    }
+  }
+
+  private static <T> Stream<T> stream(Iterable<T> iterable) {
+    return StreamSupport.stream(
+        Spliterators.spliteratorUnknownSize(iterable.iterator(), Spliterator.ORDERED), false);
+  }
+
+  private static StringBuilder appendMergeKeys(StringBuilder sb, List<String> mergeKeys) {
+    if (mergeKeys.isEmpty()) {
+      throw new RuntimeException("merge key or primary key is required");
+    }
+    for (int i = 0; i < mergeKeys.size(); i++) {
+      if (i != 0) {
+        sb.append(" AND ");
+      }
+      String mergeKey = quoteIdentifier(mergeKeys.get(i));
+      sb.append("T.");
+      sb.append(mergeKey);
+      sb.append(" = S.");
+      sb.append(mergeKey);
+    }
+    return sb;
+  }
+
+  private static StringBuilder appendMergeRule(
+      StringBuilder sb, List<String> mergeRule, Schema schema) {
+    return mergeRule.isEmpty() ? appendMergeRule(sb, schema) : appendMergeRule(sb, mergeRule);
+  }
+
+  private static StringBuilder appendMergeRule(StringBuilder sb, List<String> mergeRule) {
+    for (int i = 0; i < mergeRule.size(); i++) {
+      if (i != 0) {
+        sb.append(", ");
+      }
+      sb.append(mergeRule.get(i));
+    }
+    return sb;
+  }
+
+  private static StringBuilder appendMergeRule(StringBuilder sb, Schema schema) {
+    for (int i = 0; i < schema.getColumnCount(); i++) {
+      if (i != 0) {
+        sb.append(", ");
+      }
+      String column = quoteIdentifier(schema.getColumnName(i));
+      sb.append("T.");
+      sb.append(column);
+      sb.append(" = S.");
+      sb.append(column);
+    }
+    return sb;
+  }
+
+  private static StringBuilder appendColumns(StringBuilder sb, Schema schema) {
+    for (int i = 0; i < schema.getColumnCount(); i++) {
+      if (i != 0) {
+        sb.append(", ");
+      }
+      sb.append(quoteIdentifier(schema.getColumnName(i)));
+    }
+    return sb;
+  }
+
+  private static String quoteIdentifier(String identifier) {
+    return "`" + identifier + "`";
+  }
+
+  public JobStatistics.QueryStatistics executeQuery(String query) {
+    int retries = this.task.getRetries();
+    String location = this.location;
+
+    try {
+      return RetryExecutor.builder()
+          .withRetryLimit(retries)
+          .withInitialRetryWaitMillis(2 * 1000)
+          .withMaxRetryWaitMillis(10 * 1000)
+          .build()
+          .runInterruptible(
+              new Retryable<JobStatistics.QueryStatistics>() {
+                @Override
+                public JobStatistics.QueryStatistics call() {
+                  UUID uuid = UUID.randomUUID();
+                  String jobId = String.format("embulk_query_job_%s", uuid.toString());
+
+                  QueryJobConfiguration queryConfig =
+                      QueryJobConfiguration.newBuilder(query).setUseLegacySql(false).build();
+                  JobId.Builder jobIdBuilder = JobId.newBuilder().setJob(jobId);
+                  if (location != null) {
+                    jobIdBuilder.setLocation(location);
+                  }
+
+                  Job job =
+                      bigquery.create(
+                          JobInfo.newBuilder(queryConfig).setJobId(jobIdBuilder.build()).build());
+                  return (JobStatistics.QueryStatistics) waitForQuery(job);
+                }
+
+                @Override
+                public boolean isRetryableException(Exception exception) {
+                  return exception instanceof BigqueryBackendException
+                      || exception instanceof BigqueryRateLimitExceededException
+                      || exception instanceof BigqueryInternalException;
+                }
+
+                @Override
+                public void onRetry(
+                    Exception exception, int retryCount, int retryLimit, int retryWait)
+                    throws RetryGiveupException {
+                  String message =
+                      String.format(
+                          "embulk-output-bigquery: Query job failed. Retrying %d/%d after %d seconds. Message: %s",
+                          retryCount, retryLimit, retryWait / 1000, exception.getMessage());
+                  if (retryCount % retries == 0) {
+                    logger.warn(message, exception);
+                  } else {
+                    logger.warn(message);
+                  }
+                }
+
+                @Override
+                public void onGiveup(Exception firstException, Exception lastException)
+                    throws RetryGiveupException {
+                  logger.error("embulk-output-bigquery: Give up retrying for Query job");
+                }
+              });
+
+    } catch (RetryGiveupException ex) {
+      if (ex.getCause() instanceof BigqueryException) {
+        throw (BigqueryException) ex.getCause();
+      }
+      // TODO:
+      throw new RuntimeException(ex);
+    } catch (InterruptedException ex) {
+      throw new BigqueryException("interrupted");
+    }
+  }
+
+  public boolean deleteTable(String table) {
+    return deleteTable(table, null);
+  }
+
+  public boolean deleteTable(String table, String dataset) {
+    if (dataset == null) {
+      dataset = this.dataset;
+    }
+    String chompedTable = BigqueryUtil.chompPartitionDecorator(table);
+    return deleteTableOrPartition(chompedTable, dataset);
+  }
+
+  public boolean deleteTableOrPartition(String table) {
+    return deleteTableOrPartition(table, null);
+  }
+
+  //  if `table` with a partition decorator is given, a partition is deleted.
+  public boolean deleteTableOrPartition(String table, String dataset) {
+    if (dataset == null) {
+      dataset = this.dataset;
+    }
+    logger.info(String.format("embulk-output-bigquery: Delete table... %s.%s", dataset, table));
+    return this.bigquery.delete(TableId.of(dataset, table));
+  }
+
+  private JobStatistics waitForLoad(Job job) throws BigqueryException {
+    return new BigqueryJobWaiter(this.task, this, job).waitFor("Load");
+  }
+
+  private JobStatistics waitForCopy(Job job) throws BigqueryException {
+    return new BigqueryJobWaiter(this.task, this, job).waitFor("Copy");
+  }
+
+  private JobStatistics waitForQuery(Job job) throws BigqueryException {
+    return new BigqueryJobWaiter(this.task, this, job).waitFor("Query");
+  }
+
+  protected com.google.cloud.bigquery.Schema buildSchema(
+      Schema schema, List<BigqueryColumnOption> columnOptions) {
+    // TODO: support schema file
+
+    if (this.task.getTemplateTable().isPresent()) {
+      TableId tableId = TableId.of(this.dataset, this.task.getTemplateTable().get());
+      Table table = this.bigquery.getTable(tableId);
+      return table.getDefinition().getSchema();
     }
 
-    protected Field.Builder createFieldBuilder(PluginTask task, Column col, Optional<BigqueryColumnOption> columnOption) {
-        StandardSQLTypeName sqlTypeName = getStandardSQLTypeNameByEmbulkType(col.getType());
-        LegacySQLTypeName legacySQLTypeName = getLegacySQLTypeNameByEmbulkType(col.getType());
+    List<Field> fields = new ArrayList<>();
 
-        if (columnOption.isPresent()) {
-            BigqueryColumnOption colOpt = columnOption.get();
-            if (colOpt.getType().isPresent()) {
-                if (task.getEnableStandardSQL()) {
-                    sqlTypeName = StandardSQLTypeName.valueOf(colOpt.getType().get());
-                } else {
-                    legacySQLTypeName = LegacySQLTypeName.valueOf(colOpt.getType().get());
-                }
-            }
+    for (Column col : schema.getColumns()) {
+      Field.Mode fieldMode = Field.Mode.NULLABLE;
+      Optional<BigqueryColumnOption> columnOption =
+          BigqueryUtil.findColumnOption(col.getName(), columnOptions);
+      Field.Builder fieldBuilder = createFieldBuilder(task, col, columnOption);
+
+      if (columnOption.isPresent()) {
+        BigqueryColumnOption colOpt = columnOption.get();
+        if (!colOpt.getMode().isEmpty()) {
+          fieldMode = Field.Mode.valueOf(colOpt.getMode());
         }
+        fieldBuilder.setMode(fieldMode);
+
+        if (colOpt.getDescription().isPresent()) {
+          fieldBuilder.setDescription(colOpt.getDescription().get());
+        }
+      }
+      //  TODO:: support field for JSON type
+      Field field = fieldBuilder.build();
+      fields.add(field);
+    }
+    return com.google.cloud.bigquery.Schema.of(fields);
+  }
+
+  protected Field.Builder createFieldBuilder(
+      PluginTask task, Column col, Optional<BigqueryColumnOption> columnOption) {
+    StandardSQLTypeName sqlTypeName = getStandardSQLTypeNameByEmbulkType(col.getType());
+    LegacySQLTypeName legacySQLTypeName = getLegacySQLTypeNameByEmbulkType(col.getType());
+
+    if (columnOption.isPresent()) {
+      BigqueryColumnOption colOpt = columnOption.get();
+      if (colOpt.getType().isPresent()) {
         if (task.getEnableStandardSQL()) {
-            return Field.newBuilder(col.getName(), sqlTypeName);
+          sqlTypeName = StandardSQLTypeName.valueOf(colOpt.getType().get());
         } else {
-            return Field.newBuilder(col.getName(), legacySQLTypeName);
+          legacySQLTypeName = LegacySQLTypeName.valueOf(colOpt.getType().get());
         }
+      }
     }
-
-    protected StandardSQLTypeName getStandardSQLTypeNameByEmbulkType(Type type) {
-        if (type instanceof BooleanType) {
-            return StandardSQLTypeName.BOOL;
-        } else if (type instanceof LongType) {
-            return StandardSQLTypeName.INT64;
-        } else if (type instanceof DoubleType) {
-            return StandardSQLTypeName.FLOAT64;
-        } else if (type instanceof StringType) {
-            return StandardSQLTypeName.STRING;
-        } else if (type instanceof TimestampType) {
-            return StandardSQLTypeName.TIMESTAMP;
-        } else if (type instanceof JsonType) {
-            return StandardSQLTypeName.STRING;
-        } else {
-            throw new RuntimeException("never reach here");
-        }
+    if (task.getEnableStandardSQL()) {
+      return Field.newBuilder(col.getName(), sqlTypeName);
+    } else {
+      return Field.newBuilder(col.getName(), legacySQLTypeName);
     }
+  }
 
-    protected LegacySQLTypeName getLegacySQLTypeNameByEmbulkType(Type type) {
-        if (type instanceof BooleanType) {
-            return LegacySQLTypeName.BOOLEAN;
-        } else if (type instanceof LongType) {
-            return LegacySQLTypeName.INTEGER;
-        } else if (type instanceof DoubleType) {
-            return LegacySQLTypeName.FLOAT;
-        } else if (type instanceof StringType) {
-            return LegacySQLTypeName.STRING;
-        } else if (type instanceof TimestampType) {
-            return LegacySQLTypeName.TIMESTAMP;
-        } else if (type instanceof JsonType) {
-            return LegacySQLTypeName.STRING;
-        } else {
-            throw new RuntimeException("never reach here");
-        }
-
+  protected StandardSQLTypeName getStandardSQLTypeNameByEmbulkType(Type type) {
+    if (type instanceof BooleanType) {
+      return StandardSQLTypeName.BOOL;
+    } else if (type instanceof LongType) {
+      return StandardSQLTypeName.INT64;
+    } else if (type instanceof DoubleType) {
+      return StandardSQLTypeName.FLOAT64;
+    } else if (type instanceof StringType) {
+      return StandardSQLTypeName.STRING;
+    } else if (type instanceof TimestampType) {
+      return StandardSQLTypeName.TIMESTAMP;
+    } else if (type instanceof JsonType) {
+      return StandardSQLTypeName.STRING;
+    } else {
+      throw new RuntimeException("never reach here");
     }
+  }
+
+  protected LegacySQLTypeName getLegacySQLTypeNameByEmbulkType(Type type) {
+    if (type instanceof BooleanType) {
+      return LegacySQLTypeName.BOOLEAN;
+    } else if (type instanceof LongType) {
+      return LegacySQLTypeName.INTEGER;
+    } else if (type instanceof DoubleType) {
+      return LegacySQLTypeName.FLOAT;
+    } else if (type instanceof StringType) {
+      return LegacySQLTypeName.STRING;
+    } else if (type instanceof TimestampType) {
+      return LegacySQLTypeName.TIMESTAMP;
+    } else if (type instanceof JsonType) {
+      return LegacySQLTypeName.STRING;
+    } else {
+      throw new RuntimeException("never reach here");
+    }
+  }
 }

--- a/src/main/java/org/embulk/output/bigquery_java/BigqueryFileWriter.java
+++ b/src/main/java/org/embulk/output/bigquery_java/BigqueryFileWriter.java
@@ -5,83 +5,79 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.zip.GZIPOutputStream;
-
 import org.embulk.output.bigquery_java.config.PluginTask;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class BigqueryFileWriter {
-    private final Logger logger = LoggerFactory.getLogger(BigqueryFileWriter.class);
-    private PluginTask task;
-    private String compression;
-    private OutputStream os;
-    private long count = 0;
+  private final Logger logger = LoggerFactory.getLogger(BigqueryFileWriter.class);
+  private PluginTask task;
+  private String compression;
+  private OutputStream os;
+  private long count = 0;
 
-    public BigqueryFileWriter(PluginTask task) {
-        this.task = task;
-        this.compression = this.task.getCompression();
+  public BigqueryFileWriter(PluginTask task) {
+    this.task = task;
+    this.compression = this.task.getCompression();
+  }
+
+  public BigqueryFileWriter() {}
+
+  public void setTask(PluginTask task) {
+    this.task = task;
+  }
+
+  public void setCompression(String compression) {
+    this.compression = compression;
+  }
+
+  public OutputStream open(String path) throws IOException {
+    logger.info("embulk-output-bigquery: create {}", path);
+
+    this.os = new FileOutputStream(path);
+    if (this.compression.equals("GZIP")) {
+      this.os = new GZIPOutputStream(this.os);
     }
+    // embulk default page size
+    this.os = new BufferedOutputStream(this.os, 1024 * 32);
 
-    public BigqueryFileWriter() {
+    return this.os;
+  }
+
+  public OutputStream outputStream() throws IOException {
+    if (this.os != null) {
+      return this.os;
     }
+    // TODO: pid, thread id format config
+    String path =
+        String.format(
+            "%s.%d.%d%s",
+            this.task.getPathPrefix().get(),
+            BigqueryUtil.getPID(),
+            Thread.currentThread().getId(),
+            this.task.getFileExt().get());
+    return open(path);
+  }
 
-    public void setTask(PluginTask task) {
-        this.task = task;
+  public void write(byte[] bytes) {
+    try {
+      outputStream().write(bytes);
+      this.count++;
+    } catch (Exception e) {
+      logger.info(e.getMessage());
     }
+  }
 
-    public void setCompression(String compression) {
-        this.compression = compression;
+  public long getCount() {
+    return this.count;
+  }
+
+  public void close() {
+    try {
+      this.outputStream().flush();
+      this.outputStream().close();
+    } catch (Exception e) {
+      logger.info(e.getMessage());
     }
-
-    public OutputStream open(String path) throws IOException {
-        logger.info("embulk-output-bigquery: create {}", path);
-
-        this.os = new FileOutputStream(path);
-        if (this.compression.equals("GZIP")) {
-            this.os = new GZIPOutputStream(this.os);
-        }
-        // embulk default page size
-        this.os = new BufferedOutputStream(this.os, 1024 * 32);
-
-        return this.os;
-    }
-
-    public OutputStream outputStream() throws IOException {
-        if (this.os != null) {
-            return this.os;
-        }
-        // TODO: pid, thread id format config
-        String path = String.format("%s.%d.%d%s",
-                this.task.getPathPrefix().get(),
-                BigqueryUtil.getPID(),
-                Thread.currentThread().getId(),
-                this.task.getFileExt().get());
-        return open(path);
-    }
-
-    public void write(byte[] bytes) {
-        try {
-            outputStream().write(bytes);
-            this.count++;
-        } catch (Exception e) {
-            logger.info(e.getMessage());
-        }
-    }
-
-    public long getCount() {
-        return this.count;
-    }
-
-    public void close() {
-        try {
-            this.outputStream().flush();
-            this.outputStream().close();
-        } catch (Exception e) {
-            logger.info(e.getMessage());
-        }
-    }
+  }
 }
-
-
-

--- a/src/main/java/org/embulk/output/bigquery_java/BigqueryJavaOutputPlugin.java
+++ b/src/main/java/org/embulk/output/bigquery_java/BigqueryJavaOutputPlugin.java
@@ -3,6 +3,18 @@ package org.embulk.output.bigquery_java;
 import com.google.cloud.bigquery.JobInfo;
 import com.google.cloud.bigquery.JobStatistics;
 import com.google.cloud.bigquery.Table;
+import java.io.File;
+import java.math.BigInteger;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.stream.Collectors;
 import org.embulk.config.ConfigDiff;
 import org.embulk.config.ConfigSource;
 import org.embulk.config.TaskReport;
@@ -20,229 +32,235 @@ import org.embulk.util.config.TaskMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.File;
-import java.math.BigInteger;
-import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
-import java.util.stream.Collectors;
+public class BigqueryJavaOutputPlugin implements OutputPlugin {
+  private final Logger logger = LoggerFactory.getLogger(BigqueryJavaOutputPlugin.class);
+  private List<Path> paths;
+  private final ConcurrentHashMap<Long, BigqueryFileWriter> writers = BigqueryUtil.getFileWriters();
 
-public class BigqueryJavaOutputPlugin
-        implements OutputPlugin {
-    private final Logger logger = LoggerFactory.getLogger(BigqueryJavaOutputPlugin.class);
-    private List<Path> paths;
-    private final ConcurrentHashMap<Long, BigqueryFileWriter> writers = BigqueryUtil.getFileWriters();
+  private static final ConfigMapperFactory CONFIG_MAPPER_FACTORY =
+      ConfigMapperFactory.builder().addDefaultModules().build();
 
-    private static final ConfigMapperFactory CONFIG_MAPPER_FACTORY = ConfigMapperFactory.builder().addDefaultModules().build();
+  @SuppressWarnings("deprecation") // The use of PluginTask.dump
+  @Override
+  public ConfigDiff transaction(
+      ConfigSource config, Schema schema, int taskCount, OutputPlugin.Control control) {
+    final ConfigMapper configMapper = CONFIG_MAPPER_FACTORY.createConfigMapper();
+    final PluginTask task = configMapper.map(config, PluginTask.class);
+    BigqueryConfigValidator.validate(task);
+    BigqueryTaskBuilder.build(task);
+    BigqueryClient client = new BigqueryClient(task, schema);
+    autoCreate(task, client);
 
-    @SuppressWarnings("deprecation") // The use of PluginTask.dump
-    @Override
-    public ConfigDiff transaction(ConfigSource config,
-                                  Schema schema, int taskCount,
-                                  OutputPlugin.Control control) {
-        final ConfigMapper configMapper = CONFIG_MAPPER_FACTORY.createConfigMapper();
-        final PluginTask task = configMapper.map(config, PluginTask.class);
-        BigqueryConfigValidator.validate(task);
-        BigqueryTaskBuilder.build(task);
-        BigqueryClient client = new BigqueryClient(task, schema);
-        autoCreate(task, client);
+    control.run(task.dump());
+    this.writers.values().forEach(BigqueryFileWriter::close);
+    logger.info("embulk-output-bigquery: finish to create intermediate files");
 
-        control.run(task.dump());
-        this.writers.values().forEach(BigqueryFileWriter::close);
-        logger.info("embulk-output-bigquery: finish to create intermediate files");
+    try {
+      paths = BigqueryUtil.getIntermediateFiles(task);
+    } catch (Exception e) {
+      logger.info(e.getMessage());
+      throw new RuntimeException(e);
+    }
+    if (paths.isEmpty()) {
+      logger.info("embulk-output-bigquery: Nothing for transfer");
+      client.createTableIfNotExist(task.getTable(), task.getDataset());
 
-        try {
-            paths = BigqueryUtil.getIntermediateFiles(task);
-        } catch (Exception e) {
-            logger.info(e.getMessage());
-            throw new RuntimeException(e);
-        }
-        if (paths.isEmpty()) {
-            logger.info("embulk-output-bigquery: Nothing for transfer");
-            client.createTableIfNotExist(task.getTable(), task.getDataset());
-
-            switch (task.getMode()){
-                case "merge":
-                case "append":
-                case "replace":
-                case "delete_in_advance":
-                    if(task.getTempTable().isPresent()){
-                        client.deleteTable(task.getTempTable().get());
-                    }
-                    break;
-            }
-
-            return CONFIG_MAPPER_FACTORY.newConfigDiff();
-        }
-
-        logger.debug("embulk-output-bigquery: LOAD IN PARALLEL {}",
-                paths.stream().map(Path::toString).collect(Collectors.joining("\n")));
-
-        // transfer data to BQ from files
-        ExecutorService executor = Executors.newFixedThreadPool(paths.size());
-        List<Future<JobStatistics>> jobStatisticFutures = new ArrayList<>();
-        List<JobStatistics.LoadStatistics> statistics = new ArrayList<>();
-
-        for (Path path : paths) {
-            Future<JobStatistics> jobStatisticsFuture = executor.submit(new BigqueryJobRunner(task, schema, path));
-            jobStatisticFutures.add(jobStatisticsFuture);
-        }
-
-        for (Future<JobStatistics> jobStatisticFuture : jobStatisticFutures) {
-            try {
-                statistics.add((JobStatistics.LoadStatistics) jobStatisticFuture.get());
-            } catch (Exception e) {
-                throw new RuntimeException(e);
-            }
-        }
-        BigqueryTransactionReport report = getTransactionReport(task, client, statistics, this.writers.values());
-        if (task.getAbortOnError().get() && !task.getIsSkipJobResultCheck()) {
-            if (report.getNumInputRows().compareTo(report.getNumOutputRows()) != 0) {
-                String msg = String.format("ABORT: `num_input_rows (%d)` and `num_output_rows (%d)` does not match",
-                        report.getNumInputRows(), report.getNumOutputRows());
-                throw new RuntimeException(msg);
-            }
-        }
-
-        if (task.getMode().equals("append") && task.getBeforeLoad().isPresent()) {
-            logger.info("embulk-output-bigquery: before_load will be executed");
-            logger.info("embulk-output-bigquery: {}", task.getBeforeLoad().get());
-            client.executeQuery(task.getBeforeLoad().get());
-        }
-
-        if (task.getTempTable().isPresent()) {
-            if (task.getMode().equals("merge")) {
-                client.merge(task.getTempTable().get(), task.getTable(), task.getMergeKeys().orElse(Collections.emptyList()), task.getMergeRule().orElse(Collections.emptyList()));
-            } else if (task.getMode().equals("append")) {
-                client.copy(task.getTempTable().get(), task.getTable(), task.getDataset(), JobInfo.WriteDisposition.WRITE_APPEND);
-            } else {
-                client.copy(task.getTempTable().get(), task.getTable(), task.getDataset(), JobInfo.WriteDisposition.WRITE_TRUNCATE);
-            }
+      switch (task.getMode()) {
+        case "merge":
+        case "append":
+        case "replace":
+        case "delete_in_advance":
+          if (task.getTempTable().isPresent()) {
             client.deleteTable(task.getTempTable().get());
-        }
+          }
+          break;
+      }
 
-        if (task.getDeleteFromLocalWhenJobEnd()) {
-            paths.forEach(p -> p.toFile().delete());
-        } else {
-            paths.forEach(p -> {
-                File intermediateFile = new File(p.toString());
-                if (intermediateFile.exists()) {
-                    logger.info("embulk-output-bigquery: keep {}", p.toString());
-                }
-            });
-        }
-
-        return CONFIG_MAPPER_FACTORY.newConfigDiff();
+      return CONFIG_MAPPER_FACTORY.newConfigDiff();
     }
 
-    @Override
-    public ConfigDiff resume(TaskSource taskSource,
-                             Schema schema, int taskCount,
-                             OutputPlugin.Control control) {
-        throw new UnsupportedOperationException("bigquery_java output plugin does not support resuming");
+    logger.debug(
+        "embulk-output-bigquery: LOAD IN PARALLEL {}",
+        paths.stream().map(Path::toString).collect(Collectors.joining("\n")));
+
+    // transfer data to BQ from files
+    ExecutorService executor = Executors.newFixedThreadPool(paths.size());
+    List<Future<JobStatistics>> jobStatisticFutures = new ArrayList<>();
+    List<JobStatistics.LoadStatistics> statistics = new ArrayList<>();
+
+    for (Path path : paths) {
+      Future<JobStatistics> jobStatisticsFuture =
+          executor.submit(new BigqueryJobRunner(task, schema, path));
+      jobStatisticFutures.add(jobStatisticsFuture);
     }
 
-    @Override
-    public void cleanup(TaskSource taskSource,
-                        Schema schema, int taskCount,
-                        List<TaskReport> successTaskReports) {
+    for (Future<JobStatistics> jobStatisticFuture : jobStatisticFutures) {
+      try {
+        statistics.add((JobStatistics.LoadStatistics) jobStatisticFuture.get());
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
+    }
+    BigqueryTransactionReport report =
+        getTransactionReport(task, client, statistics, this.writers.values());
+    if (task.getAbortOnError().get() && !task.getIsSkipJobResultCheck()) {
+      if (report.getNumInputRows().compareTo(report.getNumOutputRows()) != 0) {
+        String msg =
+            String.format(
+                "ABORT: `num_input_rows (%d)` and `num_output_rows (%d)` does not match",
+                report.getNumInputRows(), report.getNumOutputRows());
+        throw new RuntimeException(msg);
+      }
     }
 
-    @Override
-    public TransactionalPageOutput open(TaskSource taskSource, Schema schema, int taskIndex) {
-        final TaskMapper taskMapper = CONFIG_MAPPER_FACTORY.createTaskMapper();
-        PluginTask task = taskMapper.map(taskSource, PluginTask.class);
-        return new BigqueryPageOutput(task, schema);
+    if (task.getMode().equals("append") && task.getBeforeLoad().isPresent()) {
+      logger.info("embulk-output-bigquery: before_load will be executed");
+      logger.info("embulk-output-bigquery: {}", task.getBeforeLoad().get());
+      client.executeQuery(task.getBeforeLoad().get());
     }
 
-    protected void autoCreate(PluginTask task, BigqueryClient client){
+    if (task.getTempTable().isPresent()) {
+      if (task.getMode().equals("merge")) {
+        client.merge(
+            task.getTempTable().get(),
+            task.getTable(),
+            task.getMergeKeys().orElse(Collections.emptyList()),
+            task.getMergeRule().orElse(Collections.emptyList()));
+      } else if (task.getMode().equals("append")) {
+        client.copy(
+            task.getTempTable().get(),
+            task.getTable(),
+            task.getDataset(),
+            JobInfo.WriteDisposition.WRITE_APPEND);
+      } else {
+        client.copy(
+            task.getTempTable().get(),
+            task.getTable(),
+            task.getDataset(),
+            JobInfo.WriteDisposition.WRITE_TRUNCATE);
+      }
+      client.deleteTable(task.getTempTable().get());
+    }
 
-        if (client.getDataset(task.getDataset()) == null){
-            if (task.getAutoCreateDataset()){
-                client.createDataset(task.getDataset());
-            }else{
-                throw new BigqueryException(String.format("dataset %s is not found", task.getDataset()));
+    if (task.getDeleteFromLocalWhenJobEnd()) {
+      paths.forEach(p -> p.toFile().delete());
+    } else {
+      paths.forEach(
+          p -> {
+            File intermediateFile = new File(p.toString());
+            if (intermediateFile.exists()) {
+              logger.info("embulk-output-bigquery: keep {}", p.toString());
             }
-        }
-
-        if (task.getMode().equals("replace_backup") && task.getOldDataset().isPresent() && !task.getOldDataset().get().equals(task.getDataset())){
-           if (client.getDataset(task.getOldDataset().get()) == null){
-               if (task.getAutoCreateDataset()){
-                   client.createDataset(task.getDataset());
-               }else{
-                   throw new BigqueryException(String.format("dataset %s is not found", task.getDataset()));
-               }
-           }
-        }
-
-        switch (task.getMode()){
-            case "delete_in_advance":
-                client.deleteTableOrPartition(task.getTable());
-                client.createTableIfNotExist(task.getTempTable().get(), task.getDataset());
-                break;
-            case "replace":
-                client.createTableIfNotExist(task.getTempTable().get(), task.getDataset());
-                // TODO: create table to support partition
-                break;
-            case "append":
-                client.createTableIfNotExist(task.getTempTable().get(), task.getDataset());
-                // TODO: create table to support partition
-                break;
-            case "merge":
-                client.createTableIfNotExist(task.getTempTable().get(), task.getDataset());
-                client.createTableIfNotExist(task.getTable()); // needs for when task['table'] is a partition
-                break;
-            case "replace_backup":
-                client.createTableIfNotExist(task.getTemplateTable().get());
-                client.createTableIfNotExist(task.getTable());
-                // needs for when a partition
-                client.createTableIfNotExist(task.getOldTable().get(),task.getOldDataset().get());
-                break;
-            case "append_direct":
-                if (task.getAutoCreateTable()) {
-                    client.createTableIfNotExist(task.getTable(), task.getDataset());
-                }else{
-                    Table table = client.getTable(task.getTable());
-                    if (table == null){
-                        throw new BigqueryException(String.format("%s.%s not found, create table or enable auto_create_table", task.getDataset(), task.getTable()));
-                    }
-                }
-                break;
-            default:
-                // never reach here
-                throw new RuntimeException(String.format("mode %s is not supported", task.getMode()));
-        }
-
+          });
     }
 
+    return CONFIG_MAPPER_FACTORY.newConfigDiff();
+  }
 
-    protected BigqueryTransactionReport getTransactionReport(PluginTask task,
-                                                             BigqueryClient client,
-                                                             List<JobStatistics.LoadStatistics> statistics, Collection<BigqueryFileWriter> writers) {
-        long inputRows = writers.stream().map(BigqueryFileWriter::getCount).reduce(0L, Long::sum);
-        if (task.getIsSkipJobResultCheck()) {
-            return new BigqueryTransactionReport(BigInteger.valueOf(inputRows));
-        }
+  @Override
+  public ConfigDiff resume(
+      TaskSource taskSource, Schema schema, int taskCount, OutputPlugin.Control control) {
+    throw new UnsupportedOperationException(
+        "bigquery_java output plugin does not support resuming");
+  }
 
-        long responseRows = statistics.stream().map(JobStatistics.LoadStatistics::getOutputRows).reduce(0L, Long::sum);
-        BigInteger outputRows;
-        if (task.getTempTable().isPresent()) {
-            outputRows = client.getTable(task.getTempTable().get()).getNumRows();
+  @Override
+  public void cleanup(
+      TaskSource taskSource, Schema schema, int taskCount, List<TaskReport> successTaskReports) {}
+
+  @Override
+  public TransactionalPageOutput open(TaskSource taskSource, Schema schema, int taskIndex) {
+    final TaskMapper taskMapper = CONFIG_MAPPER_FACTORY.createTaskMapper();
+    PluginTask task = taskMapper.map(taskSource, PluginTask.class);
+    return new BigqueryPageOutput(task, schema);
+  }
+
+  protected void autoCreate(PluginTask task, BigqueryClient client) {
+
+    if (client.getDataset(task.getDataset()) == null) {
+      if (task.getAutoCreateDataset()) {
+        client.createDataset(task.getDataset());
+      } else {
+        throw new BigqueryException(String.format("dataset %s is not found", task.getDataset()));
+      }
+    }
+
+    if (task.getMode().equals("replace_backup")
+        && task.getOldDataset().isPresent()
+        && !task.getOldDataset().get().equals(task.getDataset())) {
+      if (client.getDataset(task.getOldDataset().get()) == null) {
+        if (task.getAutoCreateDataset()) {
+          client.createDataset(task.getDataset());
         } else {
-            outputRows = BigInteger.valueOf(responseRows);
+          throw new BigqueryException(String.format("dataset %s is not found", task.getDataset()));
         }
-        BigInteger rejectedRows = BigInteger.valueOf(inputRows).subtract(outputRows);
-
-        return new BigqueryTransactionReport(
-                BigInteger.valueOf(inputRows),
-                BigInteger.valueOf(responseRows),
-                outputRows,
-                rejectedRows);
+      }
     }
+
+    switch (task.getMode()) {
+      case "delete_in_advance":
+        client.deleteTableOrPartition(task.getTable());
+        client.createTableIfNotExist(task.getTempTable().get(), task.getDataset());
+        break;
+      case "replace":
+        client.createTableIfNotExist(task.getTempTable().get(), task.getDataset());
+        // TODO: create table to support partition
+        break;
+      case "append":
+        client.createTableIfNotExist(task.getTempTable().get(), task.getDataset());
+        // TODO: create table to support partition
+        break;
+      case "merge":
+        client.createTableIfNotExist(task.getTempTable().get(), task.getDataset());
+        client.createTableIfNotExist(
+            task.getTable()); // needs for when task['table'] is a partition
+        break;
+      case "replace_backup":
+        client.createTableIfNotExist(task.getTemplateTable().get());
+        client.createTableIfNotExist(task.getTable());
+        // needs for when a partition
+        client.createTableIfNotExist(task.getOldTable().get(), task.getOldDataset().get());
+        break;
+      case "append_direct":
+        if (task.getAutoCreateTable()) {
+          client.createTableIfNotExist(task.getTable(), task.getDataset());
+        } else {
+          Table table = client.getTable(task.getTable());
+          if (table == null) {
+            throw new BigqueryException(
+                String.format(
+                    "%s.%s not found, create table or enable auto_create_table",
+                    task.getDataset(), task.getTable()));
+          }
+        }
+        break;
+      default:
+        // never reach here
+        throw new RuntimeException(String.format("mode %s is not supported", task.getMode()));
+    }
+  }
+
+  protected BigqueryTransactionReport getTransactionReport(
+      PluginTask task,
+      BigqueryClient client,
+      List<JobStatistics.LoadStatistics> statistics,
+      Collection<BigqueryFileWriter> writers) {
+    long inputRows = writers.stream().map(BigqueryFileWriter::getCount).reduce(0L, Long::sum);
+    if (task.getIsSkipJobResultCheck()) {
+      return new BigqueryTransactionReport(BigInteger.valueOf(inputRows));
+    }
+
+    long responseRows =
+        statistics.stream().map(JobStatistics.LoadStatistics::getOutputRows).reduce(0L, Long::sum);
+    BigInteger outputRows;
+    if (task.getTempTable().isPresent()) {
+      outputRows = client.getTable(task.getTempTable().get()).getNumRows();
+    } else {
+      outputRows = BigInteger.valueOf(responseRows);
+    }
+    BigInteger rejectedRows = BigInteger.valueOf(inputRows).subtract(outputRows);
+
+    return new BigqueryTransactionReport(
+        BigInteger.valueOf(inputRows), BigInteger.valueOf(responseRows), outputRows, rejectedRows);
+  }
 }

--- a/src/main/java/org/embulk/output/bigquery_java/BigqueryJobRunner.java
+++ b/src/main/java/org/embulk/output/bigquery_java/BigqueryJobRunner.java
@@ -1,39 +1,35 @@
 package org.embulk.output.bigquery_java;
 
-
 import com.google.cloud.bigquery.JobInfo;
 import com.google.cloud.bigquery.JobStatistics;
+import java.nio.file.Path;
+import java.util.concurrent.Callable;
 import org.embulk.output.bigquery_java.config.PluginTask;
 import org.embulk.spi.Schema;
 
-import java.nio.file.Path;
-import java.util.concurrent.Callable;
-
 public class BigqueryJobRunner implements Callable<JobStatistics> {
-    private BigqueryClient client;
-    private Path path;
-    private PluginTask task;
-    private Schema schema;
+  private BigqueryClient client;
+  private Path path;
+  private PluginTask task;
+  private Schema schema;
 
-    public BigqueryJobRunner(PluginTask task, Schema schema, Path path) {
-        this.task = task;
-        this.path = path;
-        this.schema = schema;
+  public BigqueryJobRunner(PluginTask task, Schema schema, Path path) {
+    this.task = task;
+    this.path = path;
+    this.schema = schema;
+  }
+
+  @Override
+  public JobStatistics call() throws Exception {
+    client = new BigqueryClient(this.task, this.schema);
+    String tableName;
+    // append_direct use table name
+    if (task.getMode().equals("append_direct")) {
+      tableName = task.getTable();
+    } else {
+      tableName = task.getTempTable().get();
     }
 
-    @Override
-    public JobStatistics call() throws Exception {
-        client = new BigqueryClient(this.task, this.schema);
-        String tableName;
-        // append_direct use table name
-        if (task.getMode().equals("append_direct")){
-            tableName = task.getTable();
-        }else{
-            tableName = task.getTempTable().get();
-        }
-
-        return client.load(this.path,
-                tableName,
-                JobInfo.WriteDisposition.WRITE_APPEND);
-    }
+    return client.load(this.path, tableName, JobInfo.WriteDisposition.WRITE_APPEND);
+  }
 }

--- a/src/main/java/org/embulk/output/bigquery_java/BigqueryJobWaiter.java
+++ b/src/main/java/org/embulk/output/bigquery_java/BigqueryJobWaiter.java
@@ -19,98 +19,116 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class BigqueryJobWaiter {
-    private final Logger logger = LoggerFactory.getLogger(BigqueryJobWaiter.class);
-    private Job job;
-    private Job completedJob;
-    private Date now;
-    private Date started;
-    private long elapsed;
-    private JobStatus.State jobState;
-    private PluginTask task;
-    private BigqueryClient client;
-    private JobStatistics jobStatistics;
+  private final Logger logger = LoggerFactory.getLogger(BigqueryJobWaiter.class);
+  private Job job;
+  private Job completedJob;
+  private Date now;
+  private Date started;
+  private long elapsed;
+  private JobStatus.State jobState;
+  private PluginTask task;
+  private BigqueryClient client;
+  private JobStatistics jobStatistics;
 
-    public BigqueryJobWaiter(PluginTask task, BigqueryClient client, Job job) {
-        this.task = task;
-        this.client = client;
-        this.job = job;
+  public BigqueryJobWaiter(PluginTask task, BigqueryClient client, Job job) {
+    this.task = task;
+    this.client = client;
+    this.job = job;
+  }
+
+  public JobStatistics waitFor(String kind) throws RuntimeException {
+    this.started = new Date();
+
+    while (true) {
+      completedJob = this.client.getJob(job.getJobId());
+      jobState = completedJob.getStatus().getState();
+      now = new Date();
+      elapsed = (now.getTime() - started.getTime()) / 1000;
+      if (jobState.equals(DONE)) {
+        logger.info("embulk-output-bigquery: {} job completed... ", kind);
+        logger.info(
+            "job_id:{} elapsed_time {} sec status[DONE]",
+            completedJob.getJobId().getJob(),
+            elapsed);
+        break;
+      } else if (elapsed > this.task.getJobStatusMaxPollingTime()) {
+        logger.info("embulk-output-bigquery: {} job checking... ", kind);
+        logger.info(
+            "job_id[{}] elapsed_time {} sec status[TIMEOUT]",
+            completedJob.getJobId().getJob(),
+            elapsed);
+        throw new BigqueryJobTimeoutException(
+            String.format(
+                "Time out job_id[%s] elapsed_time %d", completedJob.getJobId().getJob(), elapsed));
+      } else {
+        logger.info("embulk-output-bigquery: {} job checking... ", kind);
+        logger.info(
+            "job_id[{}] elapsed_time {} sec status[{}]",
+            completedJob.getJobId().getJob(),
+            elapsed,
+            jobState.toString());
+        try {
+          Thread.sleep(this.task.getJobStatusPollingInterval() * 1000);
+        } catch (InterruptedException e) {
+          logger.info(e.getMessage());
+        }
+      }
     }
 
-    public JobStatistics waitFor(String kind) throws RuntimeException {
-        this.started = new Date();
+    /*
+     * JobStatus.getError()
+     * Returns the final error result of the job. If present, indicates that the job has completed and
+     * was unsuccessful.
+     *
+     * JobStatus.getExecutionErrors()
+     * Returns all errors encountered during the running of the job. Errors here do not necessarily
+     * mean that the job has completed or was unsuccessful.
+     *
+     * https://cloud.google.com/bigquery/troubleshooting-errors
+     */
+    if (completedJob.getStatus().getError() != null) {
+      String msg =
+          String.format(
+              "failed during waiting a %s job get_job(%s, errors: %s)",
+              kind, completedJob.getJobId().getJob(), bigqueryErrorToString(completedJob));
 
-        while (true) {
-            completedJob = this.client.getJob(job.getJobId());
-            jobState = completedJob.getStatus().getState();
-            now = new Date();
-            elapsed = (now.getTime() - started.getTime()) / 1000;
-            if (jobState.equals(DONE)) {
-                logger.info("embulk-output-bigquery: {} job completed... ", kind);
-                logger.info("job_id:{} elapsed_time {} sec status[DONE]", completedJob.getJobId().getJob(), elapsed);
-                break;
-            } else if (elapsed > this.task.getJobStatusMaxPollingTime()) {
-                logger.info("embulk-output-bigquery: {} job checking... ", kind);
-                logger.info("job_id[{}] elapsed_time {} sec status[TIMEOUT]", completedJob.getJobId().getJob(), elapsed);
-                throw new BigqueryJobTimeoutException(String.format("Time out job_id[%s] elapsed_time %d", completedJob.getJobId().getJob(), elapsed));
-            } else {
-                logger.info("embulk-output-bigquery: {} job checking... ", kind);
-                logger.info("job_id[{}] elapsed_time {} sec status[{}]",
-                        completedJob.getJobId().getJob(), elapsed, jobState.toString());
-                try {
-                    Thread.sleep(this.task.getJobStatusPollingInterval() * 1000);
-                } catch (InterruptedException e) {
-                    logger.info(e.getMessage());
-                }
-            }
-        }
-
-        /*
-         * JobStatus.getError()
-         * Returns the final error result of the job. If present, indicates that the job has completed and
-         * was unsuccessful.
-         *
-         * JobStatus.getExecutionErrors()
-         * Returns all errors encountered during the running of the job. Errors here do not necessarily
-         * mean that the job has completed or was unsuccessful.
-         *
-         * https://cloud.google.com/bigquery/troubleshooting-errors
-         */
-        if (completedJob.getStatus().getError() != null) {
-            String msg = String.format("failed during waiting a %s job get_job(%s, errors: %s)",
-                    kind, completedJob.getJobId().getJob(), bigqueryErrorToString(completedJob));
-
-            List<String> bigqueryErrors = completedJob.getStatus().getExecutionErrors()
-                    .stream()
-                    .map(BigQueryError::getReason)
-                    .collect(Collectors.toList());
-            if (bigqueryErrors.contains("backendError")) {
-                throw new BigqueryBackendException(msg);
-            } else if (bigqueryErrors.contains("internalError")) {
-                throw new BigqueryInternalException(msg);
-            } else if (bigqueryErrors.contains("rateLimitExceeded")) {
-                throw new BigqueryRateLimitExceededException(msg);
-            } else {
-                logger.error("embulk-output-bigquery: {}", msg);
-                throw new BigqueryException(msg);
-            }
-        }
-
-        if (completedJob.getStatus().getExecutionErrors() != null) {
-            logger.warn("embulk-output-bigquery: {} job errors... job_id:[{}] errors:{}",
-                    kind, completedJob.getJobId().getJob(), bigqueryErrorToString(completedJob));
-        }
-
-        jobStatistics = completedJob.getStatistics();
-        logger.info("embulk-output-bigquery: {} job response... job_id:[{}] response.statistics:{}",
-                kind, completedJob.getJobId().getJob(), jobStatistics.toString());
-
-        return jobStatistics;
+      List<String> bigqueryErrors =
+          completedJob.getStatus().getExecutionErrors().stream()
+              .map(BigQueryError::getReason)
+              .collect(Collectors.toList());
+      if (bigqueryErrors.contains("backendError")) {
+        throw new BigqueryBackendException(msg);
+      } else if (bigqueryErrors.contains("internalError")) {
+        throw new BigqueryInternalException(msg);
+      } else if (bigqueryErrors.contains("rateLimitExceeded")) {
+        throw new BigqueryRateLimitExceededException(msg);
+      } else {
+        logger.error("embulk-output-bigquery: {}", msg);
+        throw new BigqueryException(msg);
+      }
     }
 
-
-    private String bigqueryErrorToString(Job job) {
-        return job.getStatus().getExecutionErrors().stream()
-                .map(BigQueryError::toString)
-                .collect(Collectors.joining(", "));
+    if (completedJob.getStatus().getExecutionErrors() != null) {
+      logger.warn(
+          "embulk-output-bigquery: {} job errors... job_id:[{}] errors:{}",
+          kind,
+          completedJob.getJobId().getJob(),
+          bigqueryErrorToString(completedJob));
     }
+
+    jobStatistics = completedJob.getStatistics();
+    logger.info(
+        "embulk-output-bigquery: {} job response... job_id:[{}] response.statistics:{}",
+        kind,
+        completedJob.getJobId().getJob(),
+        jobStatistics.toString());
+
+    return jobStatistics;
+  }
+
+  private String bigqueryErrorToString(Job job) {
+    return job.getStatus().getExecutionErrors().stream()
+        .map(BigQueryError::toString)
+        .collect(Collectors.joining(", "));
+  }
 }

--- a/src/main/java/org/embulk/output/bigquery_java/BigqueryPageOutput.java
+++ b/src/main/java/org/embulk/output/bigquery_java/BigqueryPageOutput.java
@@ -1,71 +1,70 @@
 package org.embulk.output.bigquery_java;
 
 import java.util.Collections;
-
 import org.embulk.config.TaskReport;
 import org.embulk.output.bigquery_java.config.PluginTask;
-import org.embulk.output.bigquery_java.visitor.JsonColumnVisitor;
 import org.embulk.output.bigquery_java.visitor.BigqueryColumnVisitor;
-import org.embulk.spi.Exec;
+import org.embulk.output.bigquery_java.visitor.JsonColumnVisitor;
 import org.embulk.spi.Page;
 import org.embulk.spi.PageReader;
 import org.embulk.spi.Schema;
 import org.embulk.spi.TransactionalPageOutput;
-
 import org.embulk.util.config.ConfigMapperFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-
 public class BigqueryPageOutput implements TransactionalPageOutput {
-    private static final ConfigMapperFactory CONFIG_MAPPER_FACTORY = ConfigMapperFactory.builder().addDefaultModules().build();
-    private final Logger logger = LoggerFactory.getLogger(BigqueryPageOutput.class);
-    private PageReader pageReader;
-    private final Schema schema;
-    private PluginTask task;
+  private static final ConfigMapperFactory CONFIG_MAPPER_FACTORY =
+      ConfigMapperFactory.builder().addDefaultModules().build();
+  private final Logger logger = LoggerFactory.getLogger(BigqueryPageOutput.class);
+  private PageReader pageReader;
+  private final Schema schema;
+  private PluginTask task;
 
-    @SuppressWarnings("deprecation") // The use of new PageReader(schema)
-    public BigqueryPageOutput(PluginTask task, Schema schema) {
-        this.task = task;
-        this.schema = schema;
-        this.pageReader = new PageReader(schema);
-    }
+  @SuppressWarnings("deprecation") // The use of new PageReader(schema)
+  public BigqueryPageOutput(PluginTask task, Schema schema) {
+    this.task = task;
+    this.schema = schema;
+    this.pageReader = new PageReader(schema);
+  }
 
-    @Override
-    public void add(Page page) {
-        pageReader.setPage(page);
-        BigqueryThreadLocalFileWriter.setFileWriter(this.task);
-        try {
-            while (pageReader.nextRecord()) {
-                BigqueryColumnVisitor visitor = new JsonColumnVisitor(this.task,
-                        pageReader, this.task.getColumnOptions().orElse(Collections.emptyList()));
-                pageReader.getSchema().getColumns().forEach(col -> col.visit(visitor));
-                BigqueryThreadLocalFileWriter.write(visitor.getByteArray());
-            }
-        } catch (Exception e) {
-            logger.info(e.getMessage());
-        }
+  @Override
+  public void add(Page page) {
+    pageReader.setPage(page);
+    BigqueryThreadLocalFileWriter.setFileWriter(this.task);
+    try {
+      while (pageReader.nextRecord()) {
+        BigqueryColumnVisitor visitor =
+            new JsonColumnVisitor(
+                this.task,
+                pageReader,
+                this.task.getColumnOptions().orElse(Collections.emptyList()));
+        pageReader.getSchema().getColumns().forEach(col -> col.visit(visitor));
+        BigqueryThreadLocalFileWriter.write(visitor.getByteArray());
+      }
+    } catch (Exception e) {
+      logger.info(e.getMessage());
     }
+  }
 
-    @Override
-    public void finish() {
-        close();
-    }
+  @Override
+  public void finish() {
+    close();
+  }
 
-    @Override
-    public void close() {
-        if (pageReader != null) {
-            pageReader.close();
-            pageReader = null;
-        }
+  @Override
+  public void close() {
+    if (pageReader != null) {
+      pageReader.close();
+      pageReader = null;
     }
+  }
 
-    @Override
-    public void abort() {
-    }
+  @Override
+  public void abort() {}
 
-    @Override
-    public TaskReport commit() {
-        return CONFIG_MAPPER_FACTORY.newTaskReport();
-    }
+  @Override
+  public TaskReport commit() {
+    return CONFIG_MAPPER_FACTORY.newTaskReport();
+  }
 }

--- a/src/main/java/org/embulk/output/bigquery_java/BigqueryThreadLocalFileWriter.java
+++ b/src/main/java/org/embulk/output/bigquery_java/BigqueryThreadLocalFileWriter.java
@@ -1,24 +1,23 @@
 package org.embulk.output.bigquery_java;
 
 import java.util.concurrent.ConcurrentHashMap;
-
 import org.embulk.output.bigquery_java.config.PluginTask;
 
-
 public class BigqueryThreadLocalFileWriter {
-    private static ThreadLocal<BigqueryFileWriter> tl = ThreadLocal.withInitial(BigqueryFileWriter::new);
-    private static ConcurrentHashMap<Long, BigqueryFileWriter> writers;
+  private static ThreadLocal<BigqueryFileWriter> tl =
+      ThreadLocal.withInitial(BigqueryFileWriter::new);
+  private static ConcurrentHashMap<Long, BigqueryFileWriter> writers;
 
-    public static void setFileWriter(PluginTask task) {
-        BigqueryFileWriter writer = tl.get();
-        writer.setTask(task);
-        writer.setCompression(task.getCompression());
-        writers = BigqueryUtil.getFileWriters();
-        writers.put(Thread.currentThread().getId(), writer);
-        tl.set(writer);
-    }
+  public static void setFileWriter(PluginTask task) {
+    BigqueryFileWriter writer = tl.get();
+    writer.setTask(task);
+    writer.setCompression(task.getCompression());
+    writers = BigqueryUtil.getFileWriters();
+    writers.put(Thread.currentThread().getId(), writer);
+    tl.set(writer);
+  }
 
-    public static void write(byte[] bytes) {
-        tl.get().write(bytes);
-    }
+  public static void write(byte[] bytes) {
+    tl.get().write(bytes);
+  }
 }

--- a/src/main/java/org/embulk/output/bigquery_java/BigqueryTransactionReport.java
+++ b/src/main/java/org/embulk/output/bigquery_java/BigqueryTransactionReport.java
@@ -3,45 +3,53 @@ package org.embulk.output.bigquery_java;
 import java.math.BigInteger;
 
 public class BigqueryTransactionReport {
-    private BigInteger numInputRows;
-    private BigInteger numResponseRows;
-    private BigInteger numOutputRows;
-    private BigInteger numRejectedRows;
+  private BigInteger numInputRows;
+  private BigInteger numResponseRows;
+  private BigInteger numOutputRows;
+  private BigInteger numRejectedRows;
 
-    @Override
-    public String toString() {
-        return "BigqueryTransactionReport{" +
-                "numInputRows=" + numInputRows +
-                ", numResponseRows=" + numResponseRows +
-                ", numOutputRows=" + numOutputRows +
-                ", numRejectedRows=" + numRejectedRows +
-                '}';
-    }
+  @Override
+  public String toString() {
+    return "BigqueryTransactionReport{"
+        + "numInputRows="
+        + numInputRows
+        + ", numResponseRows="
+        + numResponseRows
+        + ", numOutputRows="
+        + numOutputRows
+        + ", numRejectedRows="
+        + numRejectedRows
+        + '}';
+  }
 
-    public BigqueryTransactionReport(BigInteger numInputRows, BigInteger numResponseRows, BigInteger numOutputRows, BigInteger numRejectedRows) {
-        this.numInputRows = numInputRows;
-        this.numResponseRows = numResponseRows;
-        this.numOutputRows = numOutputRows;
-        this.numRejectedRows = numRejectedRows;
-    }
+  public BigqueryTransactionReport(
+      BigInteger numInputRows,
+      BigInteger numResponseRows,
+      BigInteger numOutputRows,
+      BigInteger numRejectedRows) {
+    this.numInputRows = numInputRows;
+    this.numResponseRows = numResponseRows;
+    this.numOutputRows = numOutputRows;
+    this.numRejectedRows = numRejectedRows;
+  }
 
-    public BigqueryTransactionReport(BigInteger numInputRows) {
-        this.numInputRows = numInputRows;
-    }
+  public BigqueryTransactionReport(BigInteger numInputRows) {
+    this.numInputRows = numInputRows;
+  }
 
-    public BigInteger getNumInputRows() {
-        return numInputRows;
-    }
+  public BigInteger getNumInputRows() {
+    return numInputRows;
+  }
 
-    public BigInteger getNumResponseRows() {
-        return numResponseRows;
-    }
+  public BigInteger getNumResponseRows() {
+    return numResponseRows;
+  }
 
-    public BigInteger getNumOutputRows() {
-        return numOutputRows;
-    }
+  public BigInteger getNumOutputRows() {
+    return numOutputRows;
+  }
 
-    public BigInteger getNumRejectedRows() {
-        return numRejectedRows;
-    }
+  public BigInteger getNumRejectedRows() {
+    return numRejectedRows;
+  }
 }

--- a/src/main/java/org/embulk/output/bigquery_java/BigqueryUtil.java
+++ b/src/main/java/org/embulk/output/bigquery_java/BigqueryUtil.java
@@ -1,77 +1,74 @@
 package org.embulk.output.bigquery_java;
 
-
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.File;
 import java.nio.file.*;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.Optional;
-
+import java.util.concurrent.ConcurrentHashMap;
 import org.embulk.output.bigquery_java.config.BigqueryColumnOption;
 import org.embulk.output.bigquery_java.config.PluginTask;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-
 public class BigqueryUtil {
-    private static final String PARTITION_DECORATOR_REGEXP = "\\$.+\\z";
-    public static List<Path> getIntermediateFiles(PluginTask task) {
-        Path startDir;
-        String pathPrefix = task.getPathPrefix().get();
-        String fileExt = task.getFileExt().get();
-        File pathPrefixFile = new File(pathPrefix);
-        String glob = String.format("glob:%s*%s", pathPrefix, fileExt);
-        List<Path> r = new ArrayList<Path>(){};
+  private static final String PARTITION_DECORATOR_REGEXP = "\\$.+\\z";
 
-        if (pathPrefixFile.isDirectory()) {
-            startDir = pathPrefixFile.toPath();
-        } else {
-            startDir = pathPrefixFile.toPath().getParent();
-        }
+  public static List<Path> getIntermediateFiles(PluginTask task) {
+    Path startDir;
+    String pathPrefix = task.getPathPrefix().get();
+    String fileExt = task.getFileExt().get();
+    File pathPrefixFile = new File(pathPrefix);
+    String glob = String.format("glob:%s*%s", pathPrefix, fileExt);
+    List<Path> r = new ArrayList<Path>() {};
 
-        File[] files = startDir.toFile().listFiles();
-        if (files == null){
-            return r;
-        }
-        PathMatcher m  = FileSystems.getDefault().getPathMatcher(glob);
-        for (File file : files){
-            Path path = file.toPath();
-            if (m.matches(path)){
-                r.add(path);
-            }
-        }
-        return r;
+    if (pathPrefixFile.isDirectory()) {
+      startDir = pathPrefixFile.toPath();
+    } else {
+      startDir = pathPrefixFile.toPath().getParent();
     }
 
-    public static long getPID() {
-        String processName =
-                java.lang.management.ManagementFactory.getRuntimeMXBean().getName();
-        return Long.parseLong(processName.split("@")[0]);
+    File[] files = startDir.toFile().listFiles();
+    if (files == null) {
+      return r;
     }
+    PathMatcher m = FileSystems.getDefault().getPathMatcher(glob);
+    for (File file : files) {
+      Path path = file.toPath();
+      if (m.matches(path)) {
+        r.add(path);
+      }
+    }
+    return r;
+  }
 
-    public static ObjectMapper getObjectMapper() {
-        return ObjectMapperInstanceHolder.INSTANCE;
-    }
+  public static long getPID() {
+    String processName = java.lang.management.ManagementFactory.getRuntimeMXBean().getName();
+    return Long.parseLong(processName.split("@")[0]);
+  }
 
-    public static class ObjectMapperInstanceHolder {
-        private static final ObjectMapper INSTANCE = new ObjectMapper();
-    }
+  public static ObjectMapper getObjectMapper() {
+    return ObjectMapperInstanceHolder.INSTANCE;
+  }
 
-    public static ConcurrentHashMap<Long, BigqueryFileWriter> getFileWriters() {
-        return FileWriterHolder.INSTANCE;
-    }
+  public static class ObjectMapperInstanceHolder {
+    private static final ObjectMapper INSTANCE = new ObjectMapper();
+  }
 
-    public static class FileWriterHolder {
-        private static final ConcurrentHashMap<Long, BigqueryFileWriter> INSTANCE = new ConcurrentHashMap<>();
-    }
+  public static ConcurrentHashMap<Long, BigqueryFileWriter> getFileWriters() {
+    return FileWriterHolder.INSTANCE;
+  }
 
-    public static Optional<BigqueryColumnOption> findColumnOption(String columnName, List<BigqueryColumnOption> columnOptions) {
-        return columnOptions.stream()
-                .filter(colOpt -> colOpt.getName().equals(columnName))
-                .findFirst();
-    }
+  public static class FileWriterHolder {
+    private static final ConcurrentHashMap<Long, BigqueryFileWriter> INSTANCE =
+        new ConcurrentHashMap<>();
+  }
 
-    public static String chompPartitionDecorator(String table){
-        return table.replaceAll("\\$.+\\z", "");
-    }
+  public static Optional<BigqueryColumnOption> findColumnOption(
+      String columnName, List<BigqueryColumnOption> columnOptions) {
+    return columnOptions.stream().filter(colOpt -> colOpt.getName().equals(columnName)).findFirst();
+  }
+
+  public static String chompPartitionDecorator(String table) {
+    return table.replaceAll("\\$.+\\z", "");
+  }
 }

--- a/src/main/java/org/embulk/output/bigquery_java/BigqueryValueConverter.java
+++ b/src/main/java/org/embulk/output/bigquery_java/BigqueryValueConverter.java
@@ -1,33 +1,49 @@
 package org.embulk.output.bigquery_java;
 
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.embulk.output.bigquery_java.config.BigqueryColumnOption;
 import org.embulk.output.bigquery_java.config.BigqueryColumnOptionType;
 import org.embulk.output.bigquery_java.config.PluginTask;
 import org.embulk.output.bigquery_java.converter.*;
 
-import com.fasterxml.jackson.databind.node.ObjectNode;
-
-
 public class BigqueryValueConverter {
-    // TODO: refactor later
-    public static void convertAndSet(ObjectNode node, String name, String src, BigqueryColumnOptionType bigqueryColumnOptionType, BigqueryColumnOption columnOption) {
-        BigqueryStringConverter.convertAndSet(node, name, src, bigqueryColumnOptionType, columnOption);
-    }
+  // TODO: refactor later
+  public static void convertAndSet(
+      ObjectNode node,
+      String name,
+      String src,
+      BigqueryColumnOptionType bigqueryColumnOptionType,
+      BigqueryColumnOption columnOption) {
+    BigqueryStringConverter.convertAndSet(node, name, src, bigqueryColumnOptionType, columnOption);
+  }
 
-    @SuppressWarnings("deprecation") // The use of org.embulk.spi.time.Timestamp
-    public static void convertAndSet(ObjectNode node, String name, org.embulk.spi.time.Timestamp src, BigqueryColumnOptionType bigqueryColumnOptionType, BigqueryColumnOption columnOption, PluginTask task) {
-        BigqueryTimestampConverter.convertAndSet(node, name, src, bigqueryColumnOptionType, columnOption, task);
-    }
+  @SuppressWarnings("deprecation") // The use of org.embulk.spi.time.Timestamp
+  public static void convertAndSet(
+      ObjectNode node,
+      String name,
+      org.embulk.spi.time.Timestamp src,
+      BigqueryColumnOptionType bigqueryColumnOptionType,
+      BigqueryColumnOption columnOption,
+      PluginTask task) {
+    BigqueryTimestampConverter.convertAndSet(
+        node, name, src, bigqueryColumnOptionType, columnOption, task);
+  }
 
-    public static void convertAndSet(ObjectNode node, String name, long src, BigqueryColumnOptionType bigqueryColumnOptionType) {
-        BigqueryLongConverter.convertAndSet(node, name, src, bigqueryColumnOptionType);
-    }
+  public static void convertAndSet(
+      ObjectNode node, String name, long src, BigqueryColumnOptionType bigqueryColumnOptionType) {
+    BigqueryLongConverter.convertAndSet(node, name, src, bigqueryColumnOptionType);
+  }
 
-    public static void convertAndSet(ObjectNode node, String name, double src, BigqueryColumnOptionType bigqueryColumnOptionType) {
-        BigqueryDoubleConverter.convertAndSet(node, name, src, bigqueryColumnOptionType);
-    }
+  public static void convertAndSet(
+      ObjectNode node, String name, double src, BigqueryColumnOptionType bigqueryColumnOptionType) {
+    BigqueryDoubleConverter.convertAndSet(node, name, src, bigqueryColumnOptionType);
+  }
 
-    public static void convertAndSet(ObjectNode node, String name, boolean src, BigqueryColumnOptionType bigqueryColumnOptionType) {
-        BigqueryBooleanConverter.convertAndSet(node, name, src, bigqueryColumnOptionType);
-    }
+  public static void convertAndSet(
+      ObjectNode node,
+      String name,
+      boolean src,
+      BigqueryColumnOptionType bigqueryColumnOptionType) {
+    BigqueryBooleanConverter.convertAndSet(node, name, src, bigqueryColumnOptionType);
+  }
 }

--- a/src/main/java/org/embulk/output/bigquery_java/config/BigqueryClustering.java
+++ b/src/main/java/org/embulk/output/bigquery_java/config/BigqueryClustering.java
@@ -1,14 +1,13 @@
 package org.embulk.output.bigquery_java.config;
 
+import java.util.List;
+import java.util.Optional;
 import org.embulk.util.config.Config;
 import org.embulk.util.config.ConfigDefault;
 import org.embulk.util.config.Task;
 
-import java.util.List;
-import java.util.Optional;
-
 public interface BigqueryClustering extends Task {
-    @Config("fields")
-    @ConfigDefault("null")
-    public Optional<List<String>> getFields();
+  @Config("fields")
+  @ConfigDefault("null")
+  public Optional<List<String>> getFields();
 }

--- a/src/main/java/org/embulk/output/bigquery_java/config/BigqueryColumnOption.java
+++ b/src/main/java/org/embulk/output/bigquery_java/config/BigqueryColumnOption.java
@@ -1,51 +1,53 @@
 package org.embulk.output.bigquery_java.config;
 
+import java.util.Optional;
 import org.embulk.util.config.Config;
 import org.embulk.util.config.ConfigDefault;
 import org.embulk.util.config.Task;
 
-import java.util.Optional;
-
 public interface BigqueryColumnOption extends Task {
-    // name: column name
-    // type: BigQuery type such as BOOLEAN, INTEGER, FLOAT, STRING, TIMESTAMP, DATETIME, DATE, and RECORD. See belows for supported conversion type.
-    // boolean: BOOLEAN, STRING (default: BOOLEAN)
-    // long: BOOLEAN, INTEGER, FLOAT, STRING, TIMESTAMP (default: INTEGER)
-    // double: INTEGER, FLOAT, STRING, TIMESTAMP (default: FLOAT)
-    // string: BOOLEAN, INTEGER, FLOAT, STRING, TIMESTAMP, DATETIME, DATE, RECORD (default: STRING)
-    // timestamp: INTEGER, FLOAT, STRING, TIMESTAMP, DATETIME, DATE (default: TIMESTAMP)
-    // json: STRING, RECORD (default: STRING)
-    // mode: BigQuery mode such as NULLABLE, REQUIRED, and REPEATED (string, default: NULLABLE)
-    // fields: Describes the nested schema fields if the type property is set to RECORD. Please note that this is required for RECORD column.
-    // timestamp_format: timestamp format to convert into/from timestamp (string, default is default_timestamp_format)
+  // name: column name
+  // type: BigQuery type such as BOOLEAN, INTEGER, FLOAT, STRING, TIMESTAMP, DATETIME, DATE, and
+  // RECORD. See belows for supported conversion type.
+  // boolean: BOOLEAN, STRING (default: BOOLEAN)
+  // long: BOOLEAN, INTEGER, FLOAT, STRING, TIMESTAMP (default: INTEGER)
+  // double: INTEGER, FLOAT, STRING, TIMESTAMP (default: FLOAT)
+  // string: BOOLEAN, INTEGER, FLOAT, STRING, TIMESTAMP, DATETIME, DATE, RECORD (default: STRING)
+  // timestamp: INTEGER, FLOAT, STRING, TIMESTAMP, DATETIME, DATE (default: TIMESTAMP)
+  // json: STRING, RECORD (default: STRING)
+  // mode: BigQuery mode such as NULLABLE, REQUIRED, and REPEATED (string, default: NULLABLE)
+  // fields: Describes the nested schema fields if the type property is set to RECORD. Please note
+  // that this is required for RECORD column.
+  // timestamp_format: timestamp format to convert into/from timestamp (string, default is
+  // default_timestamp_format)
 
-    @Config("name")
-    public String getName();
+  @Config("name")
+  public String getName();
 
-    @Config("type")
-    @ConfigDefault("null")
-    public Optional<String> getType();
+  @Config("type")
+  @ConfigDefault("null")
+  public Optional<String> getType();
 
-    @Config("mode")
-    @ConfigDefault("\"NULLABLE\"")
-    public String getMode();
+  @Config("mode")
+  @ConfigDefault("\"NULLABLE\"")
+  public String getMode();
 
-    // TODO: Task builder should set value
-    @Config("timestamp_format")
-    @ConfigDefault("null")
-    public Optional<String> getTimestampFormat();
+  // TODO: Task builder should set value
+  @Config("timestamp_format")
+  @ConfigDefault("null")
+  public Optional<String> getTimestampFormat();
 
-    @Config("timezone")
-    @ConfigDefault("\"UTC\"")
-    public String getTimezone();
+  @Config("timezone")
+  @ConfigDefault("\"UTC\"")
+  public String getTimezone();
 
-    @Config("description")
-    @ConfigDefault("null")
-    public Optional<String> getDescription();
+  @Config("description")
+  @ConfigDefault("null")
+  public Optional<String> getDescription();
 
-    @Config("scale")
-    @ConfigDefault("9")
-    public int getScale();
+  @Config("scale")
+  @ConfigDefault("9")
+  public int getScale();
 
-    // TODO: fields
+  // TODO: fields
 }

--- a/src/main/java/org/embulk/output/bigquery_java/config/BigqueryColumnOptionType.java
+++ b/src/main/java/org/embulk/output/bigquery_java/config/BigqueryColumnOptionType.java
@@ -1,13 +1,13 @@
 package org.embulk.output.bigquery_java.config;
 
 public enum BigqueryColumnOptionType {
-    BOOLEAN,
-    INTEGER,
-    FLOAT,
-    STRING,
-    TIMESTAMP,
-    DATETIME,
-    DATE,
-    RECORD,
-    NUMERIC
+  BOOLEAN,
+  INTEGER,
+  FLOAT,
+  STRING,
+  TIMESTAMP,
+  DATETIME,
+  DATE,
+  RECORD,
+  NUMERIC
 }

--- a/src/main/java/org/embulk/output/bigquery_java/config/BigqueryConfigValidator.java
+++ b/src/main/java/org/embulk/output/bigquery_java/config/BigqueryConfigValidator.java
@@ -1,46 +1,50 @@
 package org.embulk.output.bigquery_java.config;
 
+import java.util.Arrays;
 import org.embulk.config.ConfigException;
 
-import java.util.Arrays;
-
 public class BigqueryConfigValidator {
-    public static void validate(PluginTask task) {
-        validateMode(task);
-        validateModeAndAutoCreteTable(task);
-        validateClustering(task);
-    }
+  public static void validate(PluginTask task) {
+    validateMode(task);
+    validateModeAndAutoCreteTable(task);
+    validateClustering(task);
+  }
 
-    public static void validateMode(PluginTask task) throws ConfigException {
-        // TODO: append_direct delete_in_advance replace_backup
-        String[] modes = {"replace", "append", "merge", "delete_in_advance", "append_direct"};
-        if (!Arrays.asList(modes).contains(task.getMode().toLowerCase())) {
-            throw new ConfigException("replace, append, merge, delete_in_advance and append_direct are supported. Stay tuned!");
-        }
+  public static void validateMode(PluginTask task) throws ConfigException {
+    // TODO: append_direct delete_in_advance replace_backup
+    String[] modes = {"replace", "append", "merge", "delete_in_advance", "append_direct"};
+    if (!Arrays.asList(modes).contains(task.getMode().toLowerCase())) {
+      throw new ConfigException(
+          "replace, append, merge, delete_in_advance and append_direct are supported. Stay tuned!");
     }
+  }
 
-    public static void validateModeAndAutoCreteTable(PluginTask task) throws ConfigException {
-        // TODO: modes are append replace delete_in_advance replace_backup and !task['auto_create_table']
-        String[] modes = {"replace", "append", "merge", "delete_in_advance"};
-        if (Arrays.asList(modes).contains(task.getMode().toLowerCase()) && !task.getAutoCreateTable()) {
-            throw new ConfigException("replace, append, merge and delete_in_advance are supported. Stay tuned!");
-        }
+  public static void validateModeAndAutoCreteTable(PluginTask task) throws ConfigException {
+    // TODO: modes are append replace delete_in_advance replace_backup and
+    // !task['auto_create_table']
+    String[] modes = {"replace", "append", "merge", "delete_in_advance"};
+    if (Arrays.asList(modes).contains(task.getMode().toLowerCase()) && !task.getAutoCreateTable()) {
+      throw new ConfigException(
+          "replace, append, merge and delete_in_advance are supported. Stay tuned!");
     }
+  }
 
-    public static void validateTimePartitioning(PluginTask task) throws ConfigException {
-        if (task.getTimePartitioning().isPresent()) {
-            String[] types = {"HOUR", "DAY", "MONTH", "YEAR"};
-            if (!Arrays.asList(types).contains(task.getTimePartitioning().get().getType().toUpperCase())) {
-                throw new ConfigException("time_partitioning.type: HOUR, DAY, MONTH and YEAR are supported.");
-            }
-        }
+  public static void validateTimePartitioning(PluginTask task) throws ConfigException {
+    if (task.getTimePartitioning().isPresent()) {
+      String[] types = {"HOUR", "DAY", "MONTH", "YEAR"};
+      if (!Arrays.asList(types)
+          .contains(task.getTimePartitioning().get().getType().toUpperCase())) {
+        throw new ConfigException(
+            "time_partitioning.type: HOUR, DAY, MONTH and YEAR are supported.");
+      }
     }
+  }
 
-    public static void validateClustering(PluginTask task) throws ConfigException{
-        if (task.getClustering().isPresent()){
-            if (!task.getClustering().get().getFields().isPresent()){
-                throw new ConfigException("`clustering` must have `fields` key");
-            }
-        }
+  public static void validateClustering(PluginTask task) throws ConfigException {
+    if (task.getClustering().isPresent()) {
+      if (!task.getClustering().get().getFields().isPresent()) {
+        throw new ConfigException("`clustering` must have `fields` key");
+      }
     }
+  }
 }

--- a/src/main/java/org/embulk/output/bigquery_java/config/BigqueryTaskBuilder.java
+++ b/src/main/java/org/embulk/output/bigquery_java/config/BigqueryTaskBuilder.java
@@ -7,54 +7,55 @@ import java.util.Optional;
 import java.util.UUID;
 
 public class BigqueryTaskBuilder {
-    private static final String uniqueName = UUID.randomUUID().toString().replace("-", "_");
+  private static final String uniqueName = UUID.randomUUID().toString().replace("-", "_");
 
-    public static PluginTask build(PluginTask task) {
-        setPathPrefix(task);
-        setFileExt(task);
-        setTempTable(task);
-        setAbortOnError(task);
-        return task;
+  public static PluginTask build(PluginTask task) {
+    setPathPrefix(task);
+    setFileExt(task);
+    setTempTable(task);
+    setAbortOnError(task);
+    return task;
+  }
+
+  protected static void setPathPrefix(PluginTask task) {
+    if (!task.getPathPrefix().isPresent()) {
+      try {
+        File tmpFile = File.createTempFile("embulk_output_bigquery_java", "");
+        task.setPathPrefix(Optional.of(tmpFile.getPath()));
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
+    }
+  }
+
+  protected static void setFileExt(PluginTask task) {
+    if (!task.getFileExt().isPresent()) {
+      if (task.getSourceFormat().equals("CSV")) {
+        task.setFileExt(Optional.of(".csv"));
+      } else {
+        task.setFileExt(Optional.of(".jsonl"));
+      }
     }
 
-    protected static void setPathPrefix(PluginTask task) {
-        if (!task.getPathPrefix().isPresent()) {
-            try {
-                File tmpFile = File.createTempFile("embulk_output_bigquery_java", "");
-                task.setPathPrefix(Optional.of(tmpFile.getPath()));
-            } catch (IOException e) {
-                throw new RuntimeException(e);
-            }
-        }
+    if (task.getCompression().equals("GZIP")) {
+      String fileExt = task.getFileExt().get() + ".gz";
+      task.setFileExt(Optional.of(fileExt));
     }
+  }
 
-    protected static void setFileExt(PluginTask task) {
-        if (!task.getFileExt().isPresent()) {
-            if (task.getSourceFormat().equals("CSV")) {
-                task.setFileExt(Optional.of(".csv"));
-            } else {
-                task.setFileExt(Optional.of(".jsonl"));
-            }
-        }
-
-        if (task.getCompression().equals("GZIP")) {
-            String fileExt = task.getFileExt().get() + ".gz";
-            task.setFileExt(Optional.of(fileExt));
-        }
+  protected static void setTempTable(PluginTask task) {
+    // TODO: support replace_backup
+    String[] modeForTempTable = {"replace", "append", "merge", "delete_in_advance"};
+    if (Arrays.asList(modeForTempTable).contains(task.getMode())) {
+      String tempTable =
+          task.getTempTable().orElse(String.format("LOAD_TEMP_%s_%s", uniqueName, task.getTable()));
+      task.setTempTable(Optional.of(tempTable));
     }
+  }
 
-    protected static void setTempTable(PluginTask task) {
-        // TODO: support replace_backup
-        String[] modeForTempTable = {"replace", "append", "merge", "delete_in_advance"};
-        if (Arrays.asList(modeForTempTable).contains(task.getMode())) {
-            String tempTable = task.getTempTable().orElse(String.format("LOAD_TEMP_%s_%s", uniqueName, task.getTable()));
-            task.setTempTable(Optional.of(tempTable));
-        }
+  protected static void setAbortOnError(PluginTask task) {
+    if (!task.getAbortOnError().isPresent()) {
+      task.setAbortOnError(Optional.of(task.getMaxBadRecords() == 0));
     }
-
-    protected static void setAbortOnError(PluginTask task) {
-        if (!task.getAbortOnError().isPresent()) {
-            task.setAbortOnError(Optional.of(task.getMaxBadRecords() == 0));
-        }
-    }
+  }
 }

--- a/src/main/java/org/embulk/output/bigquery_java/config/BigqueryTimePartitioning.java
+++ b/src/main/java/org/embulk/output/bigquery_java/config/BigqueryTimePartitioning.java
@@ -1,20 +1,19 @@
 package org.embulk.output.bigquery_java.config;
 
+import java.util.Optional;
 import org.embulk.util.config.Config;
 import org.embulk.util.config.ConfigDefault;
 import org.embulk.util.config.Task;
 
-import java.util.Optional;
-
 public interface BigqueryTimePartitioning extends Task {
-    @Config("type")
-    public String getType();
+  @Config("type")
+  public String getType();
 
-    @Config("expiration_ms")
-    @ConfigDefault("null")
-    public Optional<Long> getExpirationMs();
+  @Config("expiration_ms")
+  @ConfigDefault("null")
+  public Optional<Long> getExpirationMs();
 
-    @Config("field")
-    @ConfigDefault("null")
-    public Optional<String> getField();
+  @Config("field")
+  @ConfigDefault("null")
+  public Optional<String> getField();
 }

--- a/src/main/java/org/embulk/output/bigquery_java/config/PluginTask.java
+++ b/src/main/java/org/embulk/output/bigquery_java/config/PluginTask.java
@@ -1,165 +1,163 @@
 package org.embulk.output.bigquery_java.config;
 
+import java.util.List;
+import java.util.Optional;
 import org.embulk.util.config.Config;
 import org.embulk.util.config.ConfigDefault;
 import org.embulk.util.config.Task;
 
-import java.util.List;
-import java.util.Optional;
+public interface PluginTask extends Task {
 
-public interface PluginTask
-        extends Task {
+  @Config("mode")
+  @ConfigDefault("\"append\"")
+  String getMode();
 
-    @Config("mode")
-    @ConfigDefault("\"append\"")
-    String getMode();
+  void setMode(String mode);
 
-    void setMode(String mode);
+  // TODO: default should be application default
+  @Config("auth_method")
+  @ConfigDefault("\"service_account\"")
+  String getAuthMethod();
 
-    // TODO: default should be application default
-    @Config("auth_method")
-    @ConfigDefault("\"service_account\"")
-    String getAuthMethod();
+  @Config("json_keyfile")
+  String getJsonKeyfile();
 
-    @Config("json_keyfile")
-    String getJsonKeyfile();
+  @Config("dataset")
+  String getDataset();
 
-    @Config("dataset")
-    String getDataset();
+  @Config("table")
+  String getTable();
 
-    @Config("table")
-    String getTable();
+  @Config("old_dataset")
+  @ConfigDefault("null")
+  Optional<String> getOldDataset();
 
-    @Config("old_dataset")
-    @ConfigDefault("null")
-    Optional<String> getOldDataset();
+  @Config("old_table")
+  @ConfigDefault("null")
+  Optional<String> getOldTable();
 
-    @Config("old_table")
-    @ConfigDefault("null")
-    Optional<String> getOldTable();
+  @Config("location")
+  @ConfigDefault("null")
+  Optional<String> getLocation();
 
-    @Config("location")
-    @ConfigDefault("null")
-    Optional<String> getLocation();
+  @Config("column_options")
+  @ConfigDefault("null")
+  Optional<List<BigqueryColumnOption>> getColumnOptions();
 
-    @Config("column_options")
-    @ConfigDefault("null")
-    Optional<List<BigqueryColumnOption>> getColumnOptions();
+  @Config("compression")
+  @ConfigDefault("\"NONE\"")
+  String getCompression();
 
-    @Config("compression")
-    @ConfigDefault("\"NONE\"")
-    String getCompression();
+  @Config("source_format")
+  String getSourceFormat();
 
-    @Config("source_format")
-    String getSourceFormat();
+  @Config("path_prefix")
+  @ConfigDefault("null")
+  Optional<String> getPathPrefix();
 
-    @Config("path_prefix")
-    @ConfigDefault("null")
-    Optional<String> getPathPrefix();
+  void setPathPrefix(Optional<String> pathPrefix);
 
-    void setPathPrefix(Optional<String> pathPrefix);
+  @Config("default_timezone")
+  @ConfigDefault("\"UTC\"")
+  String getDefaultTimezone();
 
-    @Config("default_timezone")
-    @ConfigDefault("\"UTC\"")
-    String getDefaultTimezone();
+  @Config("default_timestamp_format")
+  @ConfigDefault("\"%Y-%m-%d %H:%M:%S.%6N %:z\"")
+  String getDefaultTimestampFormat();
 
-    @Config("default_timestamp_format")
-    @ConfigDefault("\"%Y-%m-%d %H:%M:%S.%6N %:z\"")
-    String getDefaultTimestampFormat();
+  // TODO: make this optional
+  @Config("file_ext")
+  @ConfigDefault("null")
+  Optional<String> getFileExt();
 
-    //TODO: make this optional
-    @Config("file_ext")
-    @ConfigDefault("null")
-    Optional<String> getFileExt();
+  void setFileExt(Optional<String> fileExt);
 
-    void setFileExt(Optional<String> fileExt);
+  @Config("encoding")
+  @ConfigDefault("\"UTF-8\"")
+  String getEncoding();
 
-    @Config("encoding")
-    @ConfigDefault("\"UTF-8\"")
-    String getEncoding();
+  @Config("auto_create_dataset")
+  @ConfigDefault("false")
+  boolean getAutoCreateDataset();
 
-    @Config("auto_create_dataset")
-    @ConfigDefault("false")
-    boolean getAutoCreateDataset();
+  @Config("auto_create_table")
+  @ConfigDefault("true")
+  boolean getAutoCreateTable();
 
-    @Config("auto_create_table")
-    @ConfigDefault("true")
-    boolean getAutoCreateTable();
+  void setAutoCreateTable(boolean autoCreateTable);
 
-    void setAutoCreateTable(boolean autoCreateTable);
+  @Config("max_bad_records")
+  @ConfigDefault("0")
+  int getMaxBadRecords();
 
-    @Config("max_bad_records")
-    @ConfigDefault("0")
-    int getMaxBadRecords();
+  @Config("ignore_unknown_values")
+  @ConfigDefault("false")
+  boolean getIgnoreUnknownValues();
 
-    @Config("ignore_unknown_values")
-    @ConfigDefault("false")
-    boolean getIgnoreUnknownValues();
+  @Config("allow_quoted_newlines")
+  @ConfigDefault("false")
+  boolean getAllowQuotedNewlines();
 
-    @Config("allow_quoted_newlines")
-    @ConfigDefault("false")
-    boolean getAllowQuotedNewlines();
+  @Config("template_table")
+  @ConfigDefault("null")
+  Optional<String> getTemplateTable();
 
-    @Config("template_table")
-    @ConfigDefault("null")
-    Optional<String> getTemplateTable();
+  @Config("job_status_polling_interval")
+  @ConfigDefault("10")
+  long getJobStatusPollingInterval();
 
-    @Config("job_status_polling_interval")
-    @ConfigDefault("10")
-    long getJobStatusPollingInterval();
+  @Config("job_status_max_polling_time")
+  @ConfigDefault("3600")
+  long getJobStatusMaxPollingTime();
 
-    @Config("job_status_max_polling_time")
-    @ConfigDefault("3600")
-    long getJobStatusMaxPollingTime();
+  @Config("temp_table")
+  @ConfigDefault("null")
+  Optional<String> getTempTable();
 
-    @Config("temp_table")
-    @ConfigDefault("null")
-    Optional<String> getTempTable();
+  void setTempTable(Optional<String> tempTable);
 
-    void setTempTable(Optional<String> tempTable);
+  @Config("delete_from_local_when_job_end")
+  @ConfigDefault("true")
+  boolean getDeleteFromLocalWhenJobEnd();
 
-    @Config("delete_from_local_when_job_end")
-    @ConfigDefault("true")
-    boolean getDeleteFromLocalWhenJobEnd();
+  @Config("is_skip_job_result_check")
+  @ConfigDefault("false")
+  boolean getIsSkipJobResultCheck();
 
-    @Config("is_skip_job_result_check")
-    @ConfigDefault("false")
-    boolean getIsSkipJobResultCheck();
+  @Config("abort_on_error")
+  @ConfigDefault("null")
+  Optional<Boolean> getAbortOnError();
 
-    @Config("abort_on_error")
-    @ConfigDefault("null")
-    Optional<Boolean> getAbortOnError();
+  void setAbortOnError(Optional<Boolean> abortOnError);
 
-    void setAbortOnError(Optional<Boolean> abortOnError);
+  // TODO: this is not corresponding to before_load SQL syntax
+  @Config("enable_standard_sql")
+  @ConfigDefault("false")
+  boolean getEnableStandardSQL();
 
-    // TODO: this is not corresponding to before_load SQL syntax
-    @Config("enable_standard_sql")
-    @ConfigDefault("false")
-    boolean getEnableStandardSQL();
+  @Config("retries")
+  @ConfigDefault("5")
+  int getRetries();
 
-    @Config("retries")
-    @ConfigDefault("5")
-    int getRetries();
+  @Config("before_load")
+  @ConfigDefault("null")
+  Optional<String> getBeforeLoad();
 
-    @Config("before_load")
-    @ConfigDefault("null")
-    Optional<String> getBeforeLoad();
+  @Config("time_partitioning")
+  @ConfigDefault("null")
+  Optional<BigqueryTimePartitioning> getTimePartitioning();
 
-    @Config("time_partitioning")
-    @ConfigDefault("null")
-    Optional<BigqueryTimePartitioning> getTimePartitioning();
+  void setTimePartitioning(Optional<BigqueryTimePartitioning> bigqueryTimePartitioning);
 
-    void setTimePartitioning(Optional<BigqueryTimePartitioning> bigqueryTimePartitioning);
+  @Config("clustering")
+  @ConfigDefault("null")
+  Optional<BigqueryClustering> getClustering();
 
-    @Config("clustering")
-    @ConfigDefault("null")
-    Optional<BigqueryClustering> getClustering();
+  @Config("merge_keys")
+  @ConfigDefault("null")
+  Optional<List<String>> getMergeKeys();
 
-    @Config("merge_keys")
-    @ConfigDefault("null")
-    Optional<List<String>> getMergeKeys();
-
-    @Config("merge_rule")
-    @ConfigDefault("null")
-    Optional<List<String>> getMergeRule();
+  @Config("merge_rule")
+  @ConfigDefault("null")
+  Optional<List<String>> getMergeRule();
 }

--- a/src/main/java/org/embulk/output/bigquery_java/converter/BigqueryBooleanConverter.java
+++ b/src/main/java/org/embulk/output/bigquery_java/converter/BigqueryBooleanConverter.java
@@ -5,16 +5,20 @@ import org.embulk.output.bigquery_java.config.BigqueryColumnOptionType;
 import org.embulk.output.bigquery_java.exception.BigqueryNotSupportedTypeException;
 
 public class BigqueryBooleanConverter {
-    public static void convertAndSet(ObjectNode node, String name, boolean src, BigqueryColumnOptionType bigqueryColumnOptionType) {
-        switch (bigqueryColumnOptionType) {
-            case BOOLEAN:
-                node.put(name, src);
-                break;
-            case STRING:
-                node.put(name, String.valueOf(src));
-                break;
-            default:
-                throw new BigqueryNotSupportedTypeException("Invalid data convert for Boolean");
-        }
+  public static void convertAndSet(
+      ObjectNode node,
+      String name,
+      boolean src,
+      BigqueryColumnOptionType bigqueryColumnOptionType) {
+    switch (bigqueryColumnOptionType) {
+      case BOOLEAN:
+        node.put(name, src);
+        break;
+      case STRING:
+        node.put(name, String.valueOf(src));
+        break;
+      default:
+        throw new BigqueryNotSupportedTypeException("Invalid data convert for Boolean");
     }
+  }
 }

--- a/src/main/java/org/embulk/output/bigquery_java/converter/BigqueryDoubleConverter.java
+++ b/src/main/java/org/embulk/output/bigquery_java/converter/BigqueryDoubleConverter.java
@@ -5,22 +5,23 @@ import org.embulk.output.bigquery_java.config.BigqueryColumnOptionType;
 import org.embulk.output.bigquery_java.exception.BigqueryNotSupportedTypeException;
 
 public class BigqueryDoubleConverter {
-    public static void convertAndSet(ObjectNode node, String name, double src, BigqueryColumnOptionType bigqueryColumnOptionType) {
-        switch (bigqueryColumnOptionType) {
-            case INTEGER:
-                node.put(name, (int) src);
-                break;
-            case FLOAT:
-                node.put(name, src);
-                break;
-            case TIMESTAMP:
-                node.put(name, src);
-                break;
-            case STRING:
-                node.put(name, String.valueOf(src));
-                break;
-            default:
-                throw new BigqueryNotSupportedTypeException("Invalid data convert for double");
-        }
+  public static void convertAndSet(
+      ObjectNode node, String name, double src, BigqueryColumnOptionType bigqueryColumnOptionType) {
+    switch (bigqueryColumnOptionType) {
+      case INTEGER:
+        node.put(name, (int) src);
+        break;
+      case FLOAT:
+        node.put(name, src);
+        break;
+      case TIMESTAMP:
+        node.put(name, src);
+        break;
+      case STRING:
+        node.put(name, String.valueOf(src));
+        break;
+      default:
+        throw new BigqueryNotSupportedTypeException("Invalid data convert for double");
     }
+  }
 }

--- a/src/main/java/org/embulk/output/bigquery_java/converter/BigqueryLongConverter.java
+++ b/src/main/java/org/embulk/output/bigquery_java/converter/BigqueryLongConverter.java
@@ -6,32 +6,32 @@ import org.embulk.output.bigquery_java.exception.BigqueryNotSupportedTypeExcepti
 import org.embulk.output.bigquery_java.exception.BigqueryTypeCastException;
 
 public class BigqueryLongConverter {
-    public static void convertAndSet(ObjectNode node, String name, long src, BigqueryColumnOptionType bigqueryColumnOptionType) {
-        switch (bigqueryColumnOptionType) {
-            case BOOLEAN:
-                if (src == 0) {
-                    node.put(name, false);
-                } else if (src == 1) {
-                    node.put(name, true);
-                } else {
-                    throw new BigqueryTypeCastException("cannot convert");
-                }
-                break;
-            case INTEGER:
-                node.put(name, src);
-                break;
-            case FLOAT:
-                node.put(name, Double.valueOf(src));
-                break;
-            case TIMESTAMP:
-                node.put(name, src);
-                break;
-            case STRING:
-                node.put(name, String.valueOf(src));
-                break;
-            default:
-                throw new BigqueryNotSupportedTypeException("Invalid data convert for double");
-
+  public static void convertAndSet(
+      ObjectNode node, String name, long src, BigqueryColumnOptionType bigqueryColumnOptionType) {
+    switch (bigqueryColumnOptionType) {
+      case BOOLEAN:
+        if (src == 0) {
+          node.put(name, false);
+        } else if (src == 1) {
+          node.put(name, true);
+        } else {
+          throw new BigqueryTypeCastException("cannot convert");
         }
+        break;
+      case INTEGER:
+        node.put(name, src);
+        break;
+      case FLOAT:
+        node.put(name, Double.valueOf(src));
+        break;
+      case TIMESTAMP:
+        node.put(name, src);
+        break;
+      case STRING:
+        node.put(name, String.valueOf(src));
+        break;
+      default:
+        throw new BigqueryNotSupportedTypeException("Invalid data convert for double");
     }
+  }
 }

--- a/src/main/java/org/embulk/output/bigquery_java/converter/BigqueryStringConverter.java
+++ b/src/main/java/org/embulk/output/bigquery_java/converter/BigqueryStringConverter.java
@@ -1,117 +1,136 @@
 package org.embulk.output.bigquery_java.converter;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.math.BigDecimal;
 import org.embulk.output.bigquery_java.config.BigqueryColumnOption;
 import org.embulk.output.bigquery_java.config.BigqueryColumnOptionType;
 import org.embulk.output.bigquery_java.exception.BigqueryNotSupportedTypeException;
 import org.embulk.output.bigquery_java.exception.BigqueryTypeCastException;
 import org.embulk.util.timestamp.TimestampFormatter;
 
-import java.math.BigDecimal;
-
 public class BigqueryStringConverter {
-    @SuppressWarnings("deprecation") // The use of org.embulk.spi.time.Timestamp
-    public static void convertAndSet(ObjectNode node, String name, String src, BigqueryColumnOptionType bigqueryColumnOptionType, BigqueryColumnOption columnOption) {
-        TimestampFormatter timestampFormat;
-        String pattern;
-        String timezone;
-        TimestampFormatter parser;
-        org.embulk.spi.time.Timestamp ts;
-        switch (bigqueryColumnOptionType) {
-            case BOOLEAN:
-                if (src == null) {
-                    node.putNull(name);
-                } else if (src.toLowerCase().equals("true")) {
-                    node.put(name, true);
-                } else if (src.toLowerCase().equals("false")) {
-                    node.put(name, false);
-                } else {
-                    throw new BigqueryTypeCastException(String.format("%s cannot be converted to BOOLEAN", src));
-                }
-                break;
-            case INTEGER:
-                int intVal;
-                try {
-                    intVal = Integer.parseInt(src);
-                } catch (NumberFormatException e) {
-                    throw new BigqueryTypeCastException(String.format("%s cannot be converted to INTEGER", src));
-                }
-                node.put(name, intVal);
-                break;
-            case FLOAT:
-                float floatVal;
-                try {
-                    floatVal = Float.parseFloat(src);
-                } catch (NumberFormatException e) {
-                    throw new BigqueryTypeCastException(String.format("%s cannot be converted to FLOAT", src));
-                }
-                node.put(name, floatVal);
-                break;
-            case STRING:
-                node.put(name, src);
-                break;
-            case TIMESTAMP:
-                if (columnOption.getTimestampFormat().isPresent()) {
-                    pattern = columnOption.getTimestampFormat().get();
-                    timezone = columnOption.getTimezone();
-                    parser = TimestampFormatter.builder(pattern, true).setDefaultZoneFromString(timezone).build();
-                    ts = org.embulk.spi.time.Timestamp.ofInstant(parser.parse(src));
-                    timestampFormat = TimestampFormatter.builder("%Y-%m-%d %H:%M:%S.%6N %:z", true).setDefaultZoneFromString(timezone).build();
-                    node.put(name, timestampFormat.format(ts.getInstant()));
-                } else {
-                    // Users must care of BQ timestamp format by themselves with no timestamp_format
-                    if (src == null) {
-                        node.putNull(name);
-                    } else {
-                        node.put(name, src);
-                    }
-                }
-                break;
-            case DATETIME:
-                if (columnOption.getTimestampFormat().isPresent()) {
-                    pattern = columnOption.getTimestampFormat().get();
-                    timezone = columnOption.getTimezone();
-                    parser = TimestampFormatter.builder(pattern, true).setDefaultZoneFromString(timezone).build();
-                    ts = org.embulk.spi.time.Timestamp.ofInstant(parser.parse(src));
-                    timestampFormat = TimestampFormatter.builder("%Y-%m-%d %H:%M:%S.%6N", true).setDefaultZoneFromString(timezone).build();
-                    node.put(name, timestampFormat.format(ts.getInstant()));
-                } else {
-                    // Users must care of BQ datetime format by themselves with no timestamp_format
-                    if (src == null) {
-                        node.putNull(name);
-                    } else {
-                        node.put(name, src);
-                    }
-                }
-                break;
-            case DATE:
-                if (columnOption.getTimestampFormat().isPresent()) {
-                    pattern = columnOption.getTimestampFormat().get();
-                    timezone = columnOption.getTimezone();
-                    parser = TimestampFormatter.builder(pattern, true).setDefaultZoneFromString(timezone).build();
-                    try {
-                        ts = org.embulk.spi.time.Timestamp.ofInstant(parser.parse(src));
-                    } catch (org.embulk.util.rubytime.RubyDateTimeParseException e) {
-                        throw new BigqueryTypeCastException(e.getMessage());
-                    }
-                    timestampFormat = TimestampFormatter.builder("%Y-%m-%d", true).setDefaultZoneFromString(timezone).build();
-                    node.put(name, timestampFormat.format(ts.getInstant()));
-                } else {
-                    // Users must care of BQ date format by themselves with no timestamp_format
-                    if (src == null) {
-                        node.putNull(name);
-                    } else {
-                        node.put(name, src);
-                    }
-                }
-                break;
-            case NUMERIC:
-                // Default value: 9, BigQuery NUMERIC type has a maximum scale of 9
-                int scale = columnOption != null ? columnOption.getScale() : 9;
-                node.put(name, new BigDecimal(src).setScale(scale, BigDecimal.ROUND_CEILING));
-                break;
-            default:
-                throw new BigqueryNotSupportedTypeException("Invalid data convert for String");
+  @SuppressWarnings("deprecation") // The use of org.embulk.spi.time.Timestamp
+  public static void convertAndSet(
+      ObjectNode node,
+      String name,
+      String src,
+      BigqueryColumnOptionType bigqueryColumnOptionType,
+      BigqueryColumnOption columnOption) {
+    TimestampFormatter timestampFormat;
+    String pattern;
+    String timezone;
+    TimestampFormatter parser;
+    org.embulk.spi.time.Timestamp ts;
+    switch (bigqueryColumnOptionType) {
+      case BOOLEAN:
+        if (src == null) {
+          node.putNull(name);
+        } else if (src.toLowerCase().equals("true")) {
+          node.put(name, true);
+        } else if (src.toLowerCase().equals("false")) {
+          node.put(name, false);
+        } else {
+          throw new BigqueryTypeCastException(
+              String.format("%s cannot be converted to BOOLEAN", src));
         }
+        break;
+      case INTEGER:
+        int intVal;
+        try {
+          intVal = Integer.parseInt(src);
+        } catch (NumberFormatException e) {
+          throw new BigqueryTypeCastException(
+              String.format("%s cannot be converted to INTEGER", src));
+        }
+        node.put(name, intVal);
+        break;
+      case FLOAT:
+        float floatVal;
+        try {
+          floatVal = Float.parseFloat(src);
+        } catch (NumberFormatException e) {
+          throw new BigqueryTypeCastException(
+              String.format("%s cannot be converted to FLOAT", src));
+        }
+        node.put(name, floatVal);
+        break;
+      case STRING:
+        node.put(name, src);
+        break;
+      case TIMESTAMP:
+        if (columnOption.getTimestampFormat().isPresent()) {
+          pattern = columnOption.getTimestampFormat().get();
+          timezone = columnOption.getTimezone();
+          parser =
+              TimestampFormatter.builder(pattern, true).setDefaultZoneFromString(timezone).build();
+          ts = org.embulk.spi.time.Timestamp.ofInstant(parser.parse(src));
+          timestampFormat =
+              TimestampFormatter.builder("%Y-%m-%d %H:%M:%S.%6N %:z", true)
+                  .setDefaultZoneFromString(timezone)
+                  .build();
+          node.put(name, timestampFormat.format(ts.getInstant()));
+        } else {
+          // Users must care of BQ timestamp format by themselves with no timestamp_format
+          if (src == null) {
+            node.putNull(name);
+          } else {
+            node.put(name, src);
+          }
+        }
+        break;
+      case DATETIME:
+        if (columnOption.getTimestampFormat().isPresent()) {
+          pattern = columnOption.getTimestampFormat().get();
+          timezone = columnOption.getTimezone();
+          parser =
+              TimestampFormatter.builder(pattern, true).setDefaultZoneFromString(timezone).build();
+          ts = org.embulk.spi.time.Timestamp.ofInstant(parser.parse(src));
+          timestampFormat =
+              TimestampFormatter.builder("%Y-%m-%d %H:%M:%S.%6N", true)
+                  .setDefaultZoneFromString(timezone)
+                  .build();
+          node.put(name, timestampFormat.format(ts.getInstant()));
+        } else {
+          // Users must care of BQ datetime format by themselves with no timestamp_format
+          if (src == null) {
+            node.putNull(name);
+          } else {
+            node.put(name, src);
+          }
+        }
+        break;
+      case DATE:
+        if (columnOption.getTimestampFormat().isPresent()) {
+          pattern = columnOption.getTimestampFormat().get();
+          timezone = columnOption.getTimezone();
+          parser =
+              TimestampFormatter.builder(pattern, true).setDefaultZoneFromString(timezone).build();
+          try {
+            ts = org.embulk.spi.time.Timestamp.ofInstant(parser.parse(src));
+          } catch (org.embulk.util.rubytime.RubyDateTimeParseException e) {
+            throw new BigqueryTypeCastException(e.getMessage());
+          }
+          timestampFormat =
+              TimestampFormatter.builder("%Y-%m-%d", true)
+                  .setDefaultZoneFromString(timezone)
+                  .build();
+          node.put(name, timestampFormat.format(ts.getInstant()));
+        } else {
+          // Users must care of BQ date format by themselves with no timestamp_format
+          if (src == null) {
+            node.putNull(name);
+          } else {
+            node.put(name, src);
+          }
+        }
+        break;
+      case NUMERIC:
+        // Default value: 9, BigQuery NUMERIC type has a maximum scale of 9
+        int scale = columnOption != null ? columnOption.getScale() : 9;
+        node.put(name, new BigDecimal(src).setScale(scale, BigDecimal.ROUND_CEILING));
+        break;
+      default:
+        throw new BigqueryNotSupportedTypeException("Invalid data convert for String");
     }
+  }
 }

--- a/src/main/java/org/embulk/output/bigquery_java/converter/BigqueryTimestampConverter.java
+++ b/src/main/java/org/embulk/output/bigquery_java/converter/BigqueryTimestampConverter.java
@@ -8,51 +8,67 @@ import org.embulk.output.bigquery_java.exception.BigqueryNotSupportedTypeExcepti
 import org.embulk.util.timestamp.TimestampFormatter;
 
 public class BigqueryTimestampConverter {
-    @SuppressWarnings("deprecation") // The use of org.embulk.spi.time.Timestamp
-    public static void convertAndSet(ObjectNode node, String name, org.embulk.spi.time.Timestamp src, BigqueryColumnOptionType bigqueryColumnOptionType, BigqueryColumnOption columnOption, PluginTask task) {
-        TimestampFormatter timestampFormat;
-        String timezone;
-        switch (bigqueryColumnOptionType) {
-            case INTEGER:
-                node.put(name, src.toEpochMilli());
-                break;
-            case FLOAT:
-                node.put(name, Double.valueOf(src.toEpochMilli()));
-                break;
-            case STRING:
-                String format = columnOption.getTimestampFormat().orElse(task.getDefaultTimestampFormat());
-                timezone = columnOption.getTimezone();
-                timestampFormat = TimestampFormatter.builder(format, true).setDefaultZoneFromString(timezone).build();
-                node.put(name, timestampFormat.format(src.getInstant()));
-                break;
-            case TIMESTAMP:
-                if (src == null) {
-                    node.putNull(name);
-                } else {
-                    timestampFormat = TimestampFormatter.builder("%Y-%m-%d %H:%M:%S.%6N %:z", true).setDefaultZoneFromString("UTC").build();
-                    node.put(name, timestampFormat.format(src.getInstant()));
-                }
-                break;
-            case DATETIME:
-                if (src == null) {
-                    node.putNull(name);
-                } else {
-                    timezone = columnOption.getTimezone();
-                    timestampFormat = TimestampFormatter.builder("%Y-%m-%d %H:%M:%S.%6N", true).setDefaultZoneFromString(timezone).build();
-                    node.put(name, timestampFormat.format(src.getInstant()));
-                }
-                break;
-            case DATE:
-                if (src == null) {
-                    node.putNull(name);
-                } else {
-                    timezone = columnOption.getTimezone();
-                    timestampFormat = TimestampFormatter.builder("%Y-%m-%d", true).setDefaultZoneFromString(timezone).build();
-                    node.put(name, timestampFormat.format(src.getInstant()));
-                }
-                break;
-            default:
-                throw new BigqueryNotSupportedTypeException("Invalid data convert for timestamp");
+  @SuppressWarnings("deprecation") // The use of org.embulk.spi.time.Timestamp
+  public static void convertAndSet(
+      ObjectNode node,
+      String name,
+      org.embulk.spi.time.Timestamp src,
+      BigqueryColumnOptionType bigqueryColumnOptionType,
+      BigqueryColumnOption columnOption,
+      PluginTask task) {
+    TimestampFormatter timestampFormat;
+    String timezone;
+    switch (bigqueryColumnOptionType) {
+      case INTEGER:
+        node.put(name, src.toEpochMilli());
+        break;
+      case FLOAT:
+        node.put(name, Double.valueOf(src.toEpochMilli()));
+        break;
+      case STRING:
+        String format = columnOption.getTimestampFormat().orElse(task.getDefaultTimestampFormat());
+        timezone = columnOption.getTimezone();
+        timestampFormat =
+            TimestampFormatter.builder(format, true).setDefaultZoneFromString(timezone).build();
+        node.put(name, timestampFormat.format(src.getInstant()));
+        break;
+      case TIMESTAMP:
+        if (src == null) {
+          node.putNull(name);
+        } else {
+          timestampFormat =
+              TimestampFormatter.builder("%Y-%m-%d %H:%M:%S.%6N %:z", true)
+                  .setDefaultZoneFromString("UTC")
+                  .build();
+          node.put(name, timestampFormat.format(src.getInstant()));
         }
+        break;
+      case DATETIME:
+        if (src == null) {
+          node.putNull(name);
+        } else {
+          timezone = columnOption.getTimezone();
+          timestampFormat =
+              TimestampFormatter.builder("%Y-%m-%d %H:%M:%S.%6N", true)
+                  .setDefaultZoneFromString(timezone)
+                  .build();
+          node.put(name, timestampFormat.format(src.getInstant()));
+        }
+        break;
+      case DATE:
+        if (src == null) {
+          node.putNull(name);
+        } else {
+          timezone = columnOption.getTimezone();
+          timestampFormat =
+              TimestampFormatter.builder("%Y-%m-%d", true)
+                  .setDefaultZoneFromString(timezone)
+                  .build();
+          node.put(name, timestampFormat.format(src.getInstant()));
+        }
+        break;
+      default:
+        throw new BigqueryNotSupportedTypeException("Invalid data convert for timestamp");
     }
+  }
 }

--- a/src/main/java/org/embulk/output/bigquery_java/exception/BigqueryBackendException.java
+++ b/src/main/java/org/embulk/output/bigquery_java/exception/BigqueryBackendException.java
@@ -1,7 +1,7 @@
 package org.embulk.output.bigquery_java.exception;
 
 public class BigqueryBackendException extends BigqueryException {
-    public BigqueryBackendException(String message) {
-        super(message);
-    }
+  public BigqueryBackendException(String message) {
+    super(message);
+  }
 }

--- a/src/main/java/org/embulk/output/bigquery_java/exception/BigqueryException.java
+++ b/src/main/java/org/embulk/output/bigquery_java/exception/BigqueryException.java
@@ -1,7 +1,7 @@
 package org.embulk.output.bigquery_java.exception;
 
 public class BigqueryException extends RuntimeException {
-    public BigqueryException(String message) {
-        super(message);
-    }
+  public BigqueryException(String message) {
+    super(message);
+  }
 }

--- a/src/main/java/org/embulk/output/bigquery_java/exception/BigqueryInternalException.java
+++ b/src/main/java/org/embulk/output/bigquery_java/exception/BigqueryInternalException.java
@@ -1,7 +1,7 @@
 package org.embulk.output.bigquery_java.exception;
 
 public class BigqueryInternalException extends BigqueryException {
-    public BigqueryInternalException(String message) {
-        super(message);
-    }
+  public BigqueryInternalException(String message) {
+    super(message);
+  }
 }

--- a/src/main/java/org/embulk/output/bigquery_java/exception/BigqueryJobTimeoutException.java
+++ b/src/main/java/org/embulk/output/bigquery_java/exception/BigqueryJobTimeoutException.java
@@ -1,7 +1,7 @@
 package org.embulk.output.bigquery_java.exception;
 
 public class BigqueryJobTimeoutException extends BigqueryException {
-    public BigqueryJobTimeoutException(String message) {
-        super(message);
-    }
+  public BigqueryJobTimeoutException(String message) {
+    super(message);
+  }
 }

--- a/src/main/java/org/embulk/output/bigquery_java/exception/BigqueryNotSupportedTypeException.java
+++ b/src/main/java/org/embulk/output/bigquery_java/exception/BigqueryNotSupportedTypeException.java
@@ -1,7 +1,7 @@
 package org.embulk.output.bigquery_java.exception;
 
 public class BigqueryNotSupportedTypeException extends BigqueryException {
-    public BigqueryNotSupportedTypeException(String message) {
-        super(message);
-    }
+  public BigqueryNotSupportedTypeException(String message) {
+    super(message);
+  }
 }

--- a/src/main/java/org/embulk/output/bigquery_java/exception/BigqueryRateLimitExceededException.java
+++ b/src/main/java/org/embulk/output/bigquery_java/exception/BigqueryRateLimitExceededException.java
@@ -1,7 +1,7 @@
 package org.embulk.output.bigquery_java.exception;
 
 public class BigqueryRateLimitExceededException extends BigqueryException {
-    public BigqueryRateLimitExceededException(String message) {
-        super(message);
-    }
+  public BigqueryRateLimitExceededException(String message) {
+    super(message);
+  }
 }

--- a/src/main/java/org/embulk/output/bigquery_java/exception/BigqueryTypeCastException.java
+++ b/src/main/java/org/embulk/output/bigquery_java/exception/BigqueryTypeCastException.java
@@ -1,7 +1,7 @@
 package org.embulk.output.bigquery_java.exception;
 
 public class BigqueryTypeCastException extends BigqueryException {
-    public BigqueryTypeCastException(String message) {
-        super(message);
-    }
+  public BigqueryTypeCastException(String message) {
+    super(message);
+  }
 }

--- a/src/main/java/org/embulk/output/bigquery_java/visitor/BigqueryColumnVisitor.java
+++ b/src/main/java/org/embulk/output/bigquery_java/visitor/BigqueryColumnVisitor.java
@@ -3,5 +3,5 @@ package org.embulk.output.bigquery_java.visitor;
 import org.embulk.spi.ColumnVisitor;
 
 public interface BigqueryColumnVisitor extends ColumnVisitor {
-    byte[] getByteArray();
+  byte[] getByteArray();
 }

--- a/src/main/java/org/embulk/output/bigquery_java/visitor/JsonColumnVisitor.java
+++ b/src/main/java/org/embulk/output/bigquery_java/visitor/JsonColumnVisitor.java
@@ -1,152 +1,152 @@
 package org.embulk.output.bigquery_java.visitor;
 
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Optional;
-
-import org.embulk.output.bigquery_java.config.BigqueryColumnOption;
 import org.embulk.output.bigquery_java.BigqueryUtil;
 import org.embulk.output.bigquery_java.BigqueryValueConverter;
+import org.embulk.output.bigquery_java.config.BigqueryColumnOption;
 import org.embulk.output.bigquery_java.config.BigqueryColumnOptionType;
 import org.embulk.output.bigquery_java.config.PluginTask;
 import org.embulk.spi.Column;
 import org.embulk.spi.PageReader;
 
-import com.fasterxml.jackson.databind.node.ObjectNode;
-
 public class JsonColumnVisitor implements BigqueryColumnVisitor {
-    final PageReader reader;
-    private final ObjectNode node;
-    private PluginTask task;
-    private List<BigqueryColumnOption> columnOptions;
+  final PageReader reader;
+  private final ObjectNode node;
+  private PluginTask task;
+  private List<BigqueryColumnOption> columnOptions;
 
-    public JsonColumnVisitor(PluginTask task, PageReader reader, List<BigqueryColumnOption> columnOptions) {
-        this.task = task;
-        this.reader = reader;
-        this.columnOptions = columnOptions;
-        this.node = BigqueryUtil.getObjectMapper().createObjectNode();
-    }
+  public JsonColumnVisitor(
+      PluginTask task, PageReader reader, List<BigqueryColumnOption> columnOptions) {
+    this.task = task;
+    this.reader = reader;
+    this.columnOptions = columnOptions;
+    this.node = BigqueryUtil.getObjectMapper().createObjectNode();
+  }
 
-    public byte[] getByteArray() {
-        String json = node.toString() + "\n";
-        return json.getBytes(StandardCharsets.UTF_8);
-    }
+  public byte[] getByteArray() {
+    String json = node.toString() + "\n";
+    return json.getBytes(StandardCharsets.UTF_8);
+  }
 
-    @Override
-    public void booleanColumn(Column column) {
-        if (reader.isNull(column)) {
-            node.putNull(column.getName());
-        } else {
-            Optional<BigqueryColumnOption> columnOption = BigqueryUtil.findColumnOption(column.getName(), this.columnOptions);
-            BigqueryColumnOptionType bigqueryColumnOptionType;
-            if (columnOption.isPresent() && columnOption.get().getType().isPresent()) {
-                bigqueryColumnOptionType = BigqueryColumnOptionType.valueOf(columnOption.get().getType().get());
-            }else{
-                bigqueryColumnOptionType = BigqueryColumnOptionType.BOOLEAN;
-            }
-            BigqueryValueConverter.convertAndSet(
-                    this.node,
-                    column.getName(),
-                    reader.getBoolean(column),
-                    bigqueryColumnOptionType);
-        }
+  @Override
+  public void booleanColumn(Column column) {
+    if (reader.isNull(column)) {
+      node.putNull(column.getName());
+    } else {
+      Optional<BigqueryColumnOption> columnOption =
+          BigqueryUtil.findColumnOption(column.getName(), this.columnOptions);
+      BigqueryColumnOptionType bigqueryColumnOptionType;
+      if (columnOption.isPresent() && columnOption.get().getType().isPresent()) {
+        bigqueryColumnOptionType =
+            BigqueryColumnOptionType.valueOf(columnOption.get().getType().get());
+      } else {
+        bigqueryColumnOptionType = BigqueryColumnOptionType.BOOLEAN;
+      }
+      BigqueryValueConverter.convertAndSet(
+          this.node, column.getName(), reader.getBoolean(column), bigqueryColumnOptionType);
     }
+  }
 
-    @Override
-    public void longColumn(Column column) {
-        if (reader.isNull(column)) {
-            node.putNull(column.getName());
-        } else {
-            Optional<BigqueryColumnOption> columnOption = BigqueryUtil.findColumnOption(column.getName(), this.columnOptions);
-            BigqueryColumnOptionType bigqueryColumnOptionType;
-            if (columnOption.isPresent() && columnOption.get().getType().isPresent()) {
-                bigqueryColumnOptionType = BigqueryColumnOptionType.valueOf(columnOption.get().getType().get());
-            }else{
-                bigqueryColumnOptionType = BigqueryColumnOptionType.INTEGER;
-            }
-            BigqueryValueConverter.convertAndSet(
-                    this.node,
-                    column.getName(),
-                    reader.getLong(column),
-                    bigqueryColumnOptionType);
-        }
+  @Override
+  public void longColumn(Column column) {
+    if (reader.isNull(column)) {
+      node.putNull(column.getName());
+    } else {
+      Optional<BigqueryColumnOption> columnOption =
+          BigqueryUtil.findColumnOption(column.getName(), this.columnOptions);
+      BigqueryColumnOptionType bigqueryColumnOptionType;
+      if (columnOption.isPresent() && columnOption.get().getType().isPresent()) {
+        bigqueryColumnOptionType =
+            BigqueryColumnOptionType.valueOf(columnOption.get().getType().get());
+      } else {
+        bigqueryColumnOptionType = BigqueryColumnOptionType.INTEGER;
+      }
+      BigqueryValueConverter.convertAndSet(
+          this.node, column.getName(), reader.getLong(column), bigqueryColumnOptionType);
     }
+  }
 
-    @Override
-    public void doubleColumn(Column column) {
-        if (reader.isNull(column)) {
-            node.putNull(column.getName());
-        } else {
-            Optional<BigqueryColumnOption> columnOption = BigqueryUtil.findColumnOption(column.getName(), this.columnOptions);
-            BigqueryColumnOptionType bigqueryColumnOptionType;
-            if (columnOption.isPresent() && columnOption.get().getType().isPresent()) {
-                bigqueryColumnOptionType = BigqueryColumnOptionType.valueOf(columnOption.get().getType().get());
-            }else{
-                bigqueryColumnOptionType = BigqueryColumnOptionType.FLOAT;
-            }
-            BigqueryValueConverter.convertAndSet(
-                    this.node,
-                    column.getName(),
-                    reader.getDouble(column),
-                    bigqueryColumnOptionType);
-        }
+  @Override
+  public void doubleColumn(Column column) {
+    if (reader.isNull(column)) {
+      node.putNull(column.getName());
+    } else {
+      Optional<BigqueryColumnOption> columnOption =
+          BigqueryUtil.findColumnOption(column.getName(), this.columnOptions);
+      BigqueryColumnOptionType bigqueryColumnOptionType;
+      if (columnOption.isPresent() && columnOption.get().getType().isPresent()) {
+        bigqueryColumnOptionType =
+            BigqueryColumnOptionType.valueOf(columnOption.get().getType().get());
+      } else {
+        bigqueryColumnOptionType = BigqueryColumnOptionType.FLOAT;
+      }
+      BigqueryValueConverter.convertAndSet(
+          this.node, column.getName(), reader.getDouble(column), bigqueryColumnOptionType);
     }
+  }
 
-    @Override
-    public void stringColumn(Column column) {
-        if (reader.isNull(column)) {
-            node.putNull(column.getName());
-        } else {
-            Optional<BigqueryColumnOption> columnOption = BigqueryUtil.findColumnOption(column.getName(), this.columnOptions);
-            BigqueryColumnOptionType bigqueryColumnOptionType;
-            BigqueryColumnOption bigqueryColumnOption = null;
-            if (columnOption.isPresent() && columnOption.get().getType().isPresent()) {
-                bigqueryColumnOptionType = BigqueryColumnOptionType.valueOf(columnOption.get().getType().get());
-                bigqueryColumnOption = columnOption.get();
-            }else{
-                bigqueryColumnOptionType = BigqueryColumnOptionType.STRING;
-            }
-            BigqueryValueConverter.convertAndSet(
-                    this.node,
-                    column.getName(),
-                    reader.getString(column),
-                    bigqueryColumnOptionType,
-                    bigqueryColumnOption);
-        }
+  @Override
+  public void stringColumn(Column column) {
+    if (reader.isNull(column)) {
+      node.putNull(column.getName());
+    } else {
+      Optional<BigqueryColumnOption> columnOption =
+          BigqueryUtil.findColumnOption(column.getName(), this.columnOptions);
+      BigqueryColumnOptionType bigqueryColumnOptionType;
+      BigqueryColumnOption bigqueryColumnOption = null;
+      if (columnOption.isPresent() && columnOption.get().getType().isPresent()) {
+        bigqueryColumnOptionType =
+            BigqueryColumnOptionType.valueOf(columnOption.get().getType().get());
+        bigqueryColumnOption = columnOption.get();
+      } else {
+        bigqueryColumnOptionType = BigqueryColumnOptionType.STRING;
+      }
+      BigqueryValueConverter.convertAndSet(
+          this.node,
+          column.getName(),
+          reader.getString(column),
+          bigqueryColumnOptionType,
+          bigqueryColumnOption);
     }
+  }
 
-    @SuppressWarnings("deprecation") // The use of PageReader.getTimestamp(column)
-    @Override
-    public void timestampColumn(Column column) {
-        if (reader.isNull(column)) {
-            node.putNull(column.getName());
-        } else {
-            Optional<BigqueryColumnOption> columnOption = BigqueryUtil.findColumnOption(column.getName(), this.columnOptions);
-            BigqueryColumnOptionType bigqueryColumnOptionType;
-            BigqueryColumnOption bigqueryColumnOption = null;
-            if (columnOption.isPresent() && columnOption.get().getType().isPresent()) {
-                bigqueryColumnOptionType = BigqueryColumnOptionType.valueOf(columnOption.get().getType().get());
-                bigqueryColumnOption = columnOption.get();
-            }else{
-                bigqueryColumnOptionType = BigqueryColumnOptionType.TIMESTAMP;
-            }
-            BigqueryValueConverter.convertAndSet(
-                    this.node,
-                    column.getName(),
-                    reader.getTimestamp(column),
-                    bigqueryColumnOptionType,
-                    bigqueryColumnOption,
-                    this.task);
-        }
+  @SuppressWarnings("deprecation") // The use of PageReader.getTimestamp(column)
+  @Override
+  public void timestampColumn(Column column) {
+    if (reader.isNull(column)) {
+      node.putNull(column.getName());
+    } else {
+      Optional<BigqueryColumnOption> columnOption =
+          BigqueryUtil.findColumnOption(column.getName(), this.columnOptions);
+      BigqueryColumnOptionType bigqueryColumnOptionType;
+      BigqueryColumnOption bigqueryColumnOption = null;
+      if (columnOption.isPresent() && columnOption.get().getType().isPresent()) {
+        bigqueryColumnOptionType =
+            BigqueryColumnOptionType.valueOf(columnOption.get().getType().get());
+        bigqueryColumnOption = columnOption.get();
+      } else {
+        bigqueryColumnOptionType = BigqueryColumnOptionType.TIMESTAMP;
+      }
+      BigqueryValueConverter.convertAndSet(
+          this.node,
+          column.getName(),
+          reader.getTimestamp(column),
+          bigqueryColumnOptionType,
+          bigqueryColumnOption,
+          this.task);
     }
+  }
 
-    @SuppressWarnings("deprecation") // The use of PageReader.getJson(column)
-    @Override
-    public void jsonColumn(Column column) {
-        if (reader.isNull(column)) {
-            node.putNull(column.getName());
-        } else {
-            node.put(column.getName(), reader.getJson(column).toJson());
-        }
+  @SuppressWarnings("deprecation") // The use of PageReader.getJson(column)
+  @Override
+  public void jsonColumn(Column column) {
+    if (reader.isNull(column)) {
+      node.putNull(column.getName());
+    } else {
+      node.put(column.getName(), reader.getJson(column).toJson());
     }
+  }
 }

--- a/src/test/java/org/embulk/output/bigquery_java/TestBigqueryJavaOutputPlugin.java
+++ b/src/test/java/org/embulk/output/bigquery_java/TestBigqueryJavaOutputPlugin.java
@@ -31,92 +31,99 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 public class TestBigqueryJavaOutputPlugin {
-    protected static final ConfigMapperFactory CONFIG_MAPPER_FACTORY =
-            ConfigMapperFactory.builder().addDefaultModules().build();
+  protected static final ConfigMapperFactory CONFIG_MAPPER_FACTORY =
+      ConfigMapperFactory.builder().addDefaultModules().build();
 
-    protected static final ConfigMapper CONFIG_MAPPER = CONFIG_MAPPER_FACTORY.createConfigMapper();
+  protected static final ConfigMapper CONFIG_MAPPER = CONFIG_MAPPER_FACTORY.createConfigMapper();
 
-    private ConfigSource config;
-    private static final String BASIC_RESOURCE_PATH = "/java/org/embulk/output/bigquery_java/";
+  private ConfigSource config;
+  private static final String BASIC_RESOURCE_PATH = "/java/org/embulk/output/bigquery_java/";
 
-    private static ConfigSource loadYamlResource(TestingEmbulk embulk, String fileName) {
-        return embulk.loadYamlResource(BASIC_RESOURCE_PATH + fileName);
-    }
+  private static ConfigSource loadYamlResource(TestingEmbulk embulk, String fileName) {
+    return embulk.loadYamlResource(BASIC_RESOURCE_PATH + fileName);
+  }
 
-    @Rule
-    public TestingEmbulk embulk = TestingEmbulk.builder()
-            .registerPlugin(OutputPlugin.class, "bigquery_java", BigqueryJavaOutputPlugin.class)
-            .registerPlugin(FileInputPlugin.class, "file", LocalFileInputPlugin.class)
-            .registerPlugin(ParserPlugin.class, "csv", CsvParserPlugin.class)
-            .build();
+  @Rule
+  public TestingEmbulk embulk =
+      TestingEmbulk.builder()
+          .registerPlugin(OutputPlugin.class, "bigquery_java", BigqueryJavaOutputPlugin.class)
+          .registerPlugin(FileInputPlugin.class, "file", LocalFileInputPlugin.class)
+          .registerPlugin(ParserPlugin.class, "csv", CsvParserPlugin.class)
+          .build();
 
-    @Rule public TemporaryFolder testFolder = new TemporaryFolder();
+  @Rule public TemporaryFolder testFolder = new TemporaryFolder();
 
-    @Test
-    public void testDefaultConfigValues() {
-        config = loadYamlResource(embulk, "base.yml");
-        PluginTask task = CONFIG_MAPPER.map(config, PluginTask.class);
-        assertEquals("replace", task.getMode());
-        assertEquals(5, task.getRetries());
-        assertEquals(0, task.getMaxBadRecords());
-        assertEquals("dataset", task.getDataset());
-        assertEquals("table", task.getTable());
-        assertEquals("service_account", task.getAuthMethod());
-        assertEquals("UTC", task.getDefaultTimezone());
-        assertEquals("UTF-8", task.getEncoding());
-        assertTrue(task.getDeleteFromLocalWhenJobEnd());
-        assertFalse(task.getAutoCreateDataset());
-        assertTrue(task.getAutoCreateTable());
-    }
+  @Test
+  public void testDefaultConfigValues() {
+    config = loadYamlResource(embulk, "base.yml");
+    PluginTask task = CONFIG_MAPPER.map(config, PluginTask.class);
+    assertEquals("replace", task.getMode());
+    assertEquals(5, task.getRetries());
+    assertEquals(0, task.getMaxBadRecords());
+    assertEquals("dataset", task.getDataset());
+    assertEquals("table", task.getTable());
+    assertEquals("service_account", task.getAuthMethod());
+    assertEquals("UTC", task.getDefaultTimezone());
+    assertEquals("UTF-8", task.getEncoding());
+    assertTrue(task.getDeleteFromLocalWhenJobEnd());
+    assertFalse(task.getAutoCreateDataset());
+    assertTrue(task.getAutoCreateTable());
+  }
 
-    @Test
-    public void testWithTimePartitioning() {
-        config = loadYamlResource(embulk, "time_partitioning.yml");
-        PluginTask task = CONFIG_MAPPER.map(config, PluginTask.class);
-        BigqueryTimePartitioning bigqueryTimePartitioning;
+  @Test
+  public void testWithTimePartitioning() {
+    config = loadYamlResource(embulk, "time_partitioning.yml");
+    PluginTask task = CONFIG_MAPPER.map(config, PluginTask.class);
+    BigqueryTimePartitioning bigqueryTimePartitioning;
 
-        assertTrue(task.getTimePartitioning().isPresent());
-        bigqueryTimePartitioning = task.getTimePartitioning().get();
-        assertEquals("DAY", bigqueryTimePartitioning.getType());
-        assertTrue(bigqueryTimePartitioning.getField().isPresent());
-        assertEquals("date", bigqueryTimePartitioning.getField().get());
-    }
+    assertTrue(task.getTimePartitioning().isPresent());
+    bigqueryTimePartitioning = task.getTimePartitioning().get();
+    assertEquals("DAY", bigqueryTimePartitioning.getType());
+    assertTrue(bigqueryTimePartitioning.getField().isPresent());
+    assertEquals("date", bigqueryTimePartitioning.getField().get());
+  }
 
-    public interface TestTask extends Task {
-        @Config("json_keyfile")
-        String getJsonKeyfile();
+  public interface TestTask extends Task {
+    @Config("json_keyfile")
+    String getJsonKeyfile();
 
-        @Config("dataset")
-        String getDataset();
+    @Config("dataset")
+    String getDataset();
 
-        @Config("table")
-        String getTable();
-    }
+    @Config("table")
+    String getTable();
+  }
 
-    @Test
-    public void testRun() throws IOException {
-        ConfigSource testConfig = EmbulkTests.config("EMBULK_OUTPUT_BIGQUERY_TEST_CONFIG");
-        TestTask testTask = CONFIG_MAPPER.map(testConfig, TestTask.class);
-        ConfigSource outConfig = CONFIG_MAPPER_FACTORY.newConfigSource();
-        outConfig.set("type", "bigquery_java");
-        outConfig.set("mode", "replace");
-        outConfig.set("json_keyfile", testTask.getJsonKeyfile());
-        outConfig.set("dataset", testTask.getDataset());
-        outConfig.set("table", testTask.getTable());
-        outConfig.set("source_format", "NEWLINE_DELIMITED_JSON");
+  @Test
+  public void testRun() throws IOException {
+    ConfigSource testConfig = EmbulkTests.config("EMBULK_OUTPUT_BIGQUERY_TEST_CONFIG");
+    TestTask testTask = CONFIG_MAPPER.map(testConfig, TestTask.class);
+    ConfigSource outConfig = CONFIG_MAPPER_FACTORY.newConfigSource();
+    outConfig.set("type", "bigquery_java");
+    outConfig.set("mode", "replace");
+    outConfig.set("json_keyfile", testTask.getJsonKeyfile());
+    outConfig.set("dataset", testTask.getDataset());
+    outConfig.set("table", testTask.getTable());
+    outConfig.set("source_format", "NEWLINE_DELIMITED_JSON");
 
-        File in = testFolder.newFile("embulk-output-bigquery_java-test.csv");
-        Files.write(in.toPath(), Arrays.asList("c0:string,c1:boolean,index:double", "test0,true,0", "test1,false,1"));
-        TestingEmbulk.RunResult runResult = embulk.runOutput(outConfig, in.toPath());
+    File in = testFolder.newFile("embulk-output-bigquery_java-test.csv");
+    Files.write(
+        in.toPath(),
+        Arrays.asList("c0:string,c1:boolean,index:double", "test0,true,0", "test1,false,1"));
+    TestingEmbulk.RunResult runResult = embulk.runOutput(outConfig, in.toPath());
 
-        BigqueryClient bigqueryClient = new BigqueryClient(CONFIG_MAPPER.map(outConfig, PluginTask.class), runResult.getOutputSchema());
-        TableResult tableResult = bigqueryClient.runQuery(String.format("SELECT * from `%s`.`%s`", testTask.getDataset(), testTask.getTable()));
-        List<FieldValueList> results = new ArrayList<>();
-        tableResult.iterateAll().forEach(results::add);
-        assertEquals(2, results.size());
-        assertEquals("test0", results.get(0).get("c0").getStringValue());
-        assertTrue(results.get(0).get("c1").getBooleanValue());
-        assertEquals("test1", results.get(1).get("c0").getStringValue());
-        assertFalse(results.get(1).get("c1").getBooleanValue());
-    }
+    BigqueryClient bigqueryClient =
+        new BigqueryClient(
+            CONFIG_MAPPER.map(outConfig, PluginTask.class), runResult.getOutputSchema());
+    TableResult tableResult =
+        bigqueryClient.runQuery(
+            String.format("SELECT * from `%s`.`%s`", testTask.getDataset(), testTask.getTable()));
+    List<FieldValueList> results = new ArrayList<>();
+    tableResult.iterateAll().forEach(results::add);
+    assertEquals(2, results.size());
+    assertEquals("test0", results.get(0).get("c0").getStringValue());
+    assertTrue(results.get(0).get("c1").getBooleanValue());
+    assertEquals("test1", results.get(1).get("c0").getStringValue());
+    assertFalse(results.get(1).get("c1").getBooleanValue());
+  }
 }

--- a/src/test/java/org/embulk/output/bigquery_java/config/TestBigqueryConfigValidator.java
+++ b/src/test/java/org/embulk/output/bigquery_java/config/TestBigqueryConfigValidator.java
@@ -13,55 +13,56 @@ import org.junit.Rule;
 import org.junit.Test;
 
 public class TestBigqueryConfigValidator {
-    protected static final ConfigMapperFactory CONFIG_MAPPER_FACTORY =
-            ConfigMapperFactory.builder().addDefaultModules().build();
+  protected static final ConfigMapperFactory CONFIG_MAPPER_FACTORY =
+      ConfigMapperFactory.builder().addDefaultModules().build();
 
-    protected static final ConfigMapper CONFIG_MAPPER = CONFIG_MAPPER_FACTORY.createConfigMapper();
+  protected static final ConfigMapper CONFIG_MAPPER = CONFIG_MAPPER_FACTORY.createConfigMapper();
 
-    private ConfigSource config;
-    private static final String BASIC_RESOURCE_PATH = "/java/org/embulk/output/bigquery_java/";
+  private ConfigSource config;
+  private static final String BASIC_RESOURCE_PATH = "/java/org/embulk/output/bigquery_java/";
 
-    private static ConfigSource loadYamlResource(TestingEmbulk embulk, String fileName) {
-        return embulk.loadYamlResource(BASIC_RESOURCE_PATH + fileName);
-    }
+  private static ConfigSource loadYamlResource(TestingEmbulk embulk, String fileName) {
+    return embulk.loadYamlResource(BASIC_RESOURCE_PATH + fileName);
+  }
 
-    @Rule
-    public TestingEmbulk embulk = TestingEmbulk.builder()
-            .registerPlugin(OutputPlugin.class, "bigquery_java", BigqueryJavaOutputPlugin.class)
-            .build();
+  @Rule
+  public TestingEmbulk embulk =
+      TestingEmbulk.builder()
+          .registerPlugin(OutputPlugin.class, "bigquery_java", BigqueryJavaOutputPlugin.class)
+          .build();
 
-    @Test
-    public void validateMode() {
-        config = loadYamlResource(embulk, "base.yml");
-        PluginTask task = CONFIG_MAPPER.map(config, PluginTask.class);
-        BigqueryConfigValidator.validateMode(task);
+  @Test
+  public void validateMode() {
+    config = loadYamlResource(embulk, "base.yml");
+    PluginTask task = CONFIG_MAPPER.map(config, PluginTask.class);
+    BigqueryConfigValidator.validateMode(task);
 
-        assertEquals("replace", task.getMode());
-    }
+    assertEquals("replace", task.getMode());
+  }
 
-    @Test(expected = ConfigException.class)
-    public void validateMode_invalid_configException() {
-        config = loadYamlResource(embulk, "base.yml");
-        PluginTask task = CONFIG_MAPPER.map(config, PluginTask.class);
-        task.setMode("foo");
-        BigqueryConfigValidator.validateMode(task);
-    }
+  @Test(expected = ConfigException.class)
+  public void validateMode_invalid_configException() {
+    config = loadYamlResource(embulk, "base.yml");
+    PluginTask task = CONFIG_MAPPER.map(config, PluginTask.class);
+    task.setMode("foo");
+    BigqueryConfigValidator.validateMode(task);
+  }
 
-    @Test
-    public void validateModeAndAutoCreteTable() {
-        config = loadYamlResource(embulk, "base.yml");
-        PluginTask task = CONFIG_MAPPER.map(config, PluginTask.class);
-        BigqueryConfigValidator.validateModeAndAutoCreteTable(task);
+  @Test
+  public void validateModeAndAutoCreteTable() {
+    config = loadYamlResource(embulk, "base.yml");
+    PluginTask task = CONFIG_MAPPER.map(config, PluginTask.class);
+    BigqueryConfigValidator.validateModeAndAutoCreteTable(task);
 
-        assertEquals("replace", task.getMode());
-        assertTrue(task.getAutoCreateTable());
-    }
+    assertEquals("replace", task.getMode());
+    assertTrue(task.getAutoCreateTable());
+  }
 
-    @Test(expected = ConfigException.class)
-    public void validateModeAndAutoCreteTable_autoCreateTable_False_configException() {
-        config = loadYamlResource(embulk, "base.yml");
-        PluginTask task = CONFIG_MAPPER.map(config, PluginTask.class);
-        task.setAutoCreateTable(false);
-        BigqueryConfigValidator.validateModeAndAutoCreteTable(task);
-    }
+  @Test(expected = ConfigException.class)
+  public void validateModeAndAutoCreteTable_autoCreateTable_False_configException() {
+    config = loadYamlResource(embulk, "base.yml");
+    PluginTask task = CONFIG_MAPPER.map(config, PluginTask.class);
+    task.setAutoCreateTable(false);
+    BigqueryConfigValidator.validateModeAndAutoCreteTable(task);
+  }
 }

--- a/src/test/java/org/embulk/output/bigquery_java/config/TestBigqueryTaskBuilder.java
+++ b/src/test/java/org/embulk/output/bigquery_java/config/TestBigqueryTaskBuilder.java
@@ -14,102 +14,109 @@ import org.junit.Rule;
 import org.junit.Test;
 
 public class TestBigqueryTaskBuilder {
-    protected static final ConfigMapperFactory CONFIG_MAPPER_FACTORY =
-            ConfigMapperFactory.builder().addDefaultModules().build();
+  protected static final ConfigMapperFactory CONFIG_MAPPER_FACTORY =
+      ConfigMapperFactory.builder().addDefaultModules().build();
 
-    protected static final ConfigMapper CONFIG_MAPPER = CONFIG_MAPPER_FACTORY.createConfigMapper();
+  protected static final ConfigMapper CONFIG_MAPPER = CONFIG_MAPPER_FACTORY.createConfigMapper();
 
-    private ConfigSource config;
-    private static final String BASIC_RESOURCE_PATH = "/java/org/embulk/output/bigquery_java/";
+  private ConfigSource config;
+  private static final String BASIC_RESOURCE_PATH = "/java/org/embulk/output/bigquery_java/";
 
-    private static ConfigSource loadYamlResource(TestingEmbulk embulk, String fileName) {
-        return embulk.loadYamlResource(BASIC_RESOURCE_PATH + fileName);
-    }
+  private static ConfigSource loadYamlResource(TestingEmbulk embulk, String fileName) {
+    return embulk.loadYamlResource(BASIC_RESOURCE_PATH + fileName);
+  }
 
-    @Rule
-    public TestingEmbulk embulk = TestingEmbulk.builder()
-            .registerPlugin(OutputPlugin.class, "bigquery_java", BigqueryJavaOutputPlugin.class)
-            .build();
+  @Rule
+  public TestingEmbulk embulk =
+      TestingEmbulk.builder()
+          .registerPlugin(OutputPlugin.class, "bigquery_java", BigqueryJavaOutputPlugin.class)
+          .build();
 
-    @Test
-    public void setAbortOnError_DefaultMaxBadRecord_True() {
-        config = embulk.configLoader().fromYamlString(
-                String.join("\n",
-                        "type: bigquery_java",
-                        "mode: replace",
-                        "auth_method: service_account",
-                        "json_keyfile: json_key.json",
-                        "dataset: dataset",
-                        "table: table",
-                        "source_format: NEWLINE_DELIMITED_JSON",
-                        "compression: GZIP",
-                        "auto_create_dataset: false",
-                        "auto_create_table: true",
-                        "path_prefix: /tmp/bq_compress/bq_",
-                        ""
-                )
-        );
-        PluginTask task = CONFIG_MAPPER.map(config, PluginTask.class);
-        BigqueryTaskBuilder.setAbortOnError(task);
+  @Test
+  public void setAbortOnError_DefaultMaxBadRecord_True() {
+    config =
+        embulk
+            .configLoader()
+            .fromYamlString(
+                String.join(
+                    "\n",
+                    "type: bigquery_java",
+                    "mode: replace",
+                    "auth_method: service_account",
+                    "json_keyfile: json_key.json",
+                    "dataset: dataset",
+                    "table: table",
+                    "source_format: NEWLINE_DELIMITED_JSON",
+                    "compression: GZIP",
+                    "auto_create_dataset: false",
+                    "auto_create_table: true",
+                    "path_prefix: /tmp/bq_compress/bq_",
+                    ""));
+    PluginTask task = CONFIG_MAPPER.map(config, PluginTask.class);
+    BigqueryTaskBuilder.setAbortOnError(task);
 
-        assertEquals(0, task.getMaxBadRecords());
-        assertEquals(true, task.getAbortOnError().get());
-    }
+    assertEquals(0, task.getMaxBadRecords());
+    assertEquals(true, task.getAbortOnError().get());
+  }
 
-    // TODO jsonl without compression, csv with/out compression
-    @Test
-    public void setFileExt_JSONL_GZIP_JSONL_GZ() {
-        config = embulk.configLoader().fromYamlString(
-                String.join("\n",
-                        "type: bigquery_java",
-                        "mode: replace",
-                        "auth_method: service_account",
-                        "json_keyfile: json_key.json",
-                        "dataset: dataset",
-                        "table: table",
-                        "source_format: NEWLINE_DELIMITED_JSON",
-                        "compression: GZIP",
-                        "auto_create_dataset: false",
-                        "auto_create_table: true",
-                        "path_prefix: /tmp/bq_compress/bq_",
-                        ""
-                )
-        );
-        PluginTask task = CONFIG_MAPPER.map(config, PluginTask.class);
+  // TODO jsonl without compression, csv with/out compression
+  @Test
+  public void setFileExt_JSONL_GZIP_JSONL_GZ() {
+    config =
+        embulk
+            .configLoader()
+            .fromYamlString(
+                String.join(
+                    "\n",
+                    "type: bigquery_java",
+                    "mode: replace",
+                    "auth_method: service_account",
+                    "json_keyfile: json_key.json",
+                    "dataset: dataset",
+                    "table: table",
+                    "source_format: NEWLINE_DELIMITED_JSON",
+                    "compression: GZIP",
+                    "auto_create_dataset: false",
+                    "auto_create_table: true",
+                    "path_prefix: /tmp/bq_compress/bq_",
+                    ""));
+    PluginTask task = CONFIG_MAPPER.map(config, PluginTask.class);
 
-        BigqueryTaskBuilder.setFileExt(task);
-        assertEquals("NEWLINE_DELIMITED_JSON", task.getSourceFormat());
-        assertEquals("GZIP", task.getCompression());
-        assertEquals(".jsonl.gz", task.getFileExt().get());
-    }
+    BigqueryTaskBuilder.setFileExt(task);
+    assertEquals("NEWLINE_DELIMITED_JSON", task.getSourceFormat());
+    assertEquals("GZIP", task.getCompression());
+    assertEquals(".jsonl.gz", task.getFileExt().get());
+  }
 
-    @Test
-    public void clustering() {
-        config = embulk.configLoader().fromYamlString(
-                String.join("\n",
-                        "type: bigquery_java",
-                        "mode: replace",
-                        "auth_method: service_account",
-                        "json_keyfile: json_key.json",
-                        "dataset: dataset",
-                        "table: table",
-                        "source_format: NEWLINE_DELIMITED_JSON",
-                        "compression: GZIP",
-                        "auto_create_dataset: false",
-                        "auto_create_table: true",
-                        "path_prefix: /tmp/bq_compress/bq_",
-                        "clustering:",
-                        "  fields:",
-                        "    - foo",
-                        "    - bar",
-                        "    - baz"
-                )
-        );
-        PluginTask task = CONFIG_MAPPER.map(config, PluginTask.class);
-        BigqueryTaskBuilder.setAbortOnError(task);
-        System.out.println(task.getClustering().get().getFields());
-        List<String> expectedOutput = Arrays.asList("foo", "bar", "baz");
+  @Test
+  public void clustering() {
+    config =
+        embulk
+            .configLoader()
+            .fromYamlString(
+                String.join(
+                    "\n",
+                    "type: bigquery_java",
+                    "mode: replace",
+                    "auth_method: service_account",
+                    "json_keyfile: json_key.json",
+                    "dataset: dataset",
+                    "table: table",
+                    "source_format: NEWLINE_DELIMITED_JSON",
+                    "compression: GZIP",
+                    "auto_create_dataset: false",
+                    "auto_create_table: true",
+                    "path_prefix: /tmp/bq_compress/bq_",
+                    "clustering:",
+                    "  fields:",
+                    "    - foo",
+                    "    - bar",
+                    "    - baz"));
+    PluginTask task = CONFIG_MAPPER.map(config, PluginTask.class);
+    BigqueryTaskBuilder.setAbortOnError(task);
+    System.out.println(task.getClustering().get().getFields());
+    List<String> expectedOutput = Arrays.asList("foo", "bar", "baz");
 
-        assertEquals(expectedOutput, task.getClustering().get().getFields().get());
-    }
+    assertEquals(expectedOutput, task.getClustering().get().getFields().get());
+  }
 }

--- a/src/test/java/org/embulk/output/bigquery_java/converter/TestBigqueryBooleanConverter.java
+++ b/src/test/java/org/embulk/output/bigquery_java/converter/TestBigqueryBooleanConverter.java
@@ -20,61 +20,61 @@ import org.junit.Rule;
 import org.junit.Test;
 
 public class TestBigqueryBooleanConverter {
-    protected static final ConfigMapperFactory CONFIG_MAPPER_FACTORY =
-            ConfigMapperFactory.builder().addDefaultModules().build();
+  protected static final ConfigMapperFactory CONFIG_MAPPER_FACTORY =
+      ConfigMapperFactory.builder().addDefaultModules().build();
 
-    protected static final ConfigMapper CONFIG_MAPPER = CONFIG_MAPPER_FACTORY.createConfigMapper();
+  protected static final ConfigMapper CONFIG_MAPPER = CONFIG_MAPPER_FACTORY.createConfigMapper();
 
-    private ConfigSource config;
-    private static final String BASIC_RESOURCE_PATH = "/java/org/embulk/output/bigquery_java/";
+  private ConfigSource config;
+  private static final String BASIC_RESOURCE_PATH = "/java/org/embulk/output/bigquery_java/";
 
-    private static ConfigSource loadYamlResource(TestingEmbulk embulk, String fileName) {
-        return embulk.loadYamlResource(BASIC_RESOURCE_PATH + fileName);
-    }
+  private static ConfigSource loadYamlResource(TestingEmbulk embulk, String fileName) {
+    return embulk.loadYamlResource(BASIC_RESOURCE_PATH + fileName);
+  }
 
-    @Rule
-    public TestingEmbulk embulk = TestingEmbulk.builder()
-            .registerPlugin(OutputPlugin.class, "bigquery_java", BigqueryJavaOutputPlugin.class)
-            .build();
+  @Rule
+  public TestingEmbulk embulk =
+      TestingEmbulk.builder()
+          .registerPlugin(OutputPlugin.class, "bigquery_java", BigqueryJavaOutputPlugin.class)
+          .build();
 
-    @Test
-    public void testConvertBooleanToString() {
-        ObjectNode node = BigqueryUtil.getObjectMapper().createObjectNode();
-        config = loadYamlResource(embulk, "base.yml");
-        List<ConfigSource> configSources = new ArrayList<>();
-        ConfigSource configSource = embulk.newConfig();
-        configSource.set("type", "STRING");
-        configSource.set("name", "key");
-        configSources.add(configSource);
-        config.set("column_options", configSources);
-        BigqueryColumnOption columnOption = CONFIG_MAPPER.map(configSource, BigqueryColumnOption.class);
-        PluginTask task = CONFIG_MAPPER.map(config, PluginTask.class);
+  @Test
+  public void testConvertBooleanToString() {
+    ObjectNode node = BigqueryUtil.getObjectMapper().createObjectNode();
+    config = loadYamlResource(embulk, "base.yml");
+    List<ConfigSource> configSources = new ArrayList<>();
+    ConfigSource configSource = embulk.newConfig();
+    configSource.set("type", "STRING");
+    configSource.set("name", "key");
+    configSources.add(configSource);
+    config.set("column_options", configSources);
+    BigqueryColumnOption columnOption = CONFIG_MAPPER.map(configSource, BigqueryColumnOption.class);
+    PluginTask task = CONFIG_MAPPER.map(config, PluginTask.class);
 
-        BigqueryBooleanConverter.convertAndSet(node, "key", true, BigqueryColumnOptionType.STRING);
+    BigqueryBooleanConverter.convertAndSet(node, "key", true, BigqueryColumnOptionType.STRING);
 
-        assertEquals(node.get("key").asText(),"true");
+    assertEquals(node.get("key").asText(), "true");
 
-        BigqueryBooleanConverter.convertAndSet(node, "key", false, BigqueryColumnOptionType.STRING);
+    BigqueryBooleanConverter.convertAndSet(node, "key", false, BigqueryColumnOptionType.STRING);
 
-        assertEquals(node.get("key").asText(),"false");
-    }
+    assertEquals(node.get("key").asText(), "false");
+  }
 
-    @Test
-    public void testConvertBooleanToBoolean() {
-        ObjectNode node = BigqueryUtil.getObjectMapper().createObjectNode();
-        config = loadYamlResource(embulk, "base.yml");
-        List<ConfigSource> configSources = new ArrayList<>();
-        ConfigSource configSource = embulk.newConfig();
-        configSource.set("type", "STRING");
-        configSource.set("name", "key");
-        configSources.add(configSource);
-        config.set("column_options", configSources);
-        BigqueryColumnOption columnOption = CONFIG_MAPPER.map(configSource, BigqueryColumnOption.class);
-        PluginTask task = CONFIG_MAPPER.map(config, PluginTask.class);
+  @Test
+  public void testConvertBooleanToBoolean() {
+    ObjectNode node = BigqueryUtil.getObjectMapper().createObjectNode();
+    config = loadYamlResource(embulk, "base.yml");
+    List<ConfigSource> configSources = new ArrayList<>();
+    ConfigSource configSource = embulk.newConfig();
+    configSource.set("type", "STRING");
+    configSource.set("name", "key");
+    configSources.add(configSource);
+    config.set("column_options", configSources);
+    BigqueryColumnOption columnOption = CONFIG_MAPPER.map(configSource, BigqueryColumnOption.class);
+    PluginTask task = CONFIG_MAPPER.map(config, PluginTask.class);
 
-        BigqueryBooleanConverter.convertAndSet(node, "key", true, BigqueryColumnOptionType.STRING);
+    BigqueryBooleanConverter.convertAndSet(node, "key", true, BigqueryColumnOptionType.STRING);
 
-        assertTrue(node.get("key").asBoolean());
-
-    }
+    assertTrue(node.get("key").asBoolean());
+  }
 }

--- a/src/test/java/org/embulk/output/bigquery_java/converter/TestBigqueryDoubleConverter.java
+++ b/src/test/java/org/embulk/output/bigquery_java/converter/TestBigqueryDoubleConverter.java
@@ -19,92 +19,93 @@ import org.junit.Rule;
 import org.junit.Test;
 
 public class TestBigqueryDoubleConverter {
-    protected static final ConfigMapperFactory CONFIG_MAPPER_FACTORY =
-            ConfigMapperFactory.builder().addDefaultModules().build();
+  protected static final ConfigMapperFactory CONFIG_MAPPER_FACTORY =
+      ConfigMapperFactory.builder().addDefaultModules().build();
 
-    protected static final ConfigMapper CONFIG_MAPPER = CONFIG_MAPPER_FACTORY.createConfigMapper();
+  protected static final ConfigMapper CONFIG_MAPPER = CONFIG_MAPPER_FACTORY.createConfigMapper();
 
-    private ConfigSource config;
-    private static final String BASIC_RESOURCE_PATH = "/java/org/embulk/output/bigquery_java/";
+  private ConfigSource config;
+  private static final String BASIC_RESOURCE_PATH = "/java/org/embulk/output/bigquery_java/";
 
-    private static ConfigSource loadYamlResource(TestingEmbulk embulk, String fileName) {
-        return embulk.loadYamlResource(BASIC_RESOURCE_PATH + fileName);
-    }
+  private static ConfigSource loadYamlResource(TestingEmbulk embulk, String fileName) {
+    return embulk.loadYamlResource(BASIC_RESOURCE_PATH + fileName);
+  }
 
-    @Rule
-    public TestingEmbulk embulk = TestingEmbulk.builder()
-            .registerPlugin(OutputPlugin.class, "bigquery_java", BigqueryJavaOutputPlugin.class)
-            .build();
+  @Rule
+  public TestingEmbulk embulk =
+      TestingEmbulk.builder()
+          .registerPlugin(OutputPlugin.class, "bigquery_java", BigqueryJavaOutputPlugin.class)
+          .build();
 
-    @Test
-    public void testConvertDoubleToString() {
-        ObjectNode node = BigqueryUtil.getObjectMapper().createObjectNode();
-        config = loadYamlResource(embulk, "base.yml");
-        List<ConfigSource> configSources = new ArrayList<>();
-        ConfigSource configSource = embulk.newConfig();
-        configSource.set("type", "STRING");
-        configSource.set("name", "key");
-        configSources.add(configSource);
-        config.set("column_options", configSources);
-        BigqueryColumnOption columnOption = CONFIG_MAPPER.map(configSource, BigqueryColumnOption.class);
-        PluginTask task = CONFIG_MAPPER.map(config, PluginTask.class);
+  @Test
+  public void testConvertDoubleToString() {
+    ObjectNode node = BigqueryUtil.getObjectMapper().createObjectNode();
+    config = loadYamlResource(embulk, "base.yml");
+    List<ConfigSource> configSources = new ArrayList<>();
+    ConfigSource configSource = embulk.newConfig();
+    configSource.set("type", "STRING");
+    configSource.set("name", "key");
+    configSources.add(configSource);
+    config.set("column_options", configSources);
+    BigqueryColumnOption columnOption = CONFIG_MAPPER.map(configSource, BigqueryColumnOption.class);
+    PluginTask task = CONFIG_MAPPER.map(config, PluginTask.class);
 
-        BigqueryDoubleConverter.convertAndSet(node, "key", 1.0, BigqueryColumnOptionType.STRING);
+    BigqueryDoubleConverter.convertAndSet(node, "key", 1.0, BigqueryColumnOptionType.STRING);
 
-        assertEquals(node.get("key").asText(),"1.0");
-    }
+    assertEquals(node.get("key").asText(), "1.0");
+  }
 
-    @Test
-    public void testConvertDoubleToInteger() {
-        ObjectNode node = BigqueryUtil.getObjectMapper().createObjectNode();
-        config = loadYamlResource(embulk, "base.yml");
-        List<ConfigSource> configSources = new ArrayList<>();
-        ConfigSource configSource = embulk.newConfig();
-        configSource.set("type", "INTEGER");
-        configSource.set("name", "key");
-        configSources.add(configSource);
-        config.set("column_options", configSources);
-        BigqueryColumnOption columnOption = CONFIG_MAPPER.map(configSource, BigqueryColumnOption.class);
-        PluginTask task = CONFIG_MAPPER.map(config, PluginTask.class);
+  @Test
+  public void testConvertDoubleToInteger() {
+    ObjectNode node = BigqueryUtil.getObjectMapper().createObjectNode();
+    config = loadYamlResource(embulk, "base.yml");
+    List<ConfigSource> configSources = new ArrayList<>();
+    ConfigSource configSource = embulk.newConfig();
+    configSource.set("type", "INTEGER");
+    configSource.set("name", "key");
+    configSources.add(configSource);
+    config.set("column_options", configSources);
+    BigqueryColumnOption columnOption = CONFIG_MAPPER.map(configSource, BigqueryColumnOption.class);
+    PluginTask task = CONFIG_MAPPER.map(config, PluginTask.class);
 
-        BigqueryDoubleConverter.convertAndSet(node, "key", 1.0, BigqueryColumnOptionType.FLOAT);
+    BigqueryDoubleConverter.convertAndSet(node, "key", 1.0, BigqueryColumnOptionType.FLOAT);
 
-        assertEquals(node.get("key").asInt(),1, 0);
-    }
+    assertEquals(node.get("key").asInt(), 1, 0);
+  }
 
-    @Test
-    public void testConvertDoubleToDouble() {
-        ObjectNode node = BigqueryUtil.getObjectMapper().createObjectNode();
-        config = loadYamlResource(embulk, "base.yml");
-        List<ConfigSource> configSources = new ArrayList<>();
-        ConfigSource configSource = embulk.newConfig();
-        configSource.set("type", "DOUBLE");
-        configSource.set("name", "key");
-        configSources.add(configSource);
-        config.set("column_options", configSources);
-        BigqueryColumnOption columnOption = CONFIG_MAPPER.map(configSource, BigqueryColumnOption.class);
-        PluginTask task = CONFIG_MAPPER.map(config, PluginTask.class);
+  @Test
+  public void testConvertDoubleToDouble() {
+    ObjectNode node = BigqueryUtil.getObjectMapper().createObjectNode();
+    config = loadYamlResource(embulk, "base.yml");
+    List<ConfigSource> configSources = new ArrayList<>();
+    ConfigSource configSource = embulk.newConfig();
+    configSource.set("type", "DOUBLE");
+    configSource.set("name", "key");
+    configSources.add(configSource);
+    config.set("column_options", configSources);
+    BigqueryColumnOption columnOption = CONFIG_MAPPER.map(configSource, BigqueryColumnOption.class);
+    PluginTask task = CONFIG_MAPPER.map(config, PluginTask.class);
 
-        BigqueryDoubleConverter.convertAndSet(node, "key", 1.0, BigqueryColumnOptionType.FLOAT);
+    BigqueryDoubleConverter.convertAndSet(node, "key", 1.0, BigqueryColumnOptionType.FLOAT);
 
-        assertEquals(node.get("key").asDouble(),1.0, 0);
-    }
+    assertEquals(node.get("key").asDouble(), 1.0, 0);
+  }
 
-    @Test
-    public void testConvertDoubleToTimestamp() {
-        ObjectNode node = BigqueryUtil.getObjectMapper().createObjectNode();
-        config = loadYamlResource(embulk, "base.yml");
-        List<ConfigSource> configSources = new ArrayList<>();
-        ConfigSource configSource = embulk.newConfig();
-        configSource.set("type", "TIMESTAMP");
-        configSource.set("name", "key");
-        configSources.add(configSource);
-        config.set("column_options", configSources);
-        BigqueryColumnOption columnOption = CONFIG_MAPPER.map(configSource, BigqueryColumnOption.class);
-        PluginTask task = CONFIG_MAPPER.map(config, PluginTask.class);
+  @Test
+  public void testConvertDoubleToTimestamp() {
+    ObjectNode node = BigqueryUtil.getObjectMapper().createObjectNode();
+    config = loadYamlResource(embulk, "base.yml");
+    List<ConfigSource> configSources = new ArrayList<>();
+    ConfigSource configSource = embulk.newConfig();
+    configSource.set("type", "TIMESTAMP");
+    configSource.set("name", "key");
+    configSources.add(configSource);
+    config.set("column_options", configSources);
+    BigqueryColumnOption columnOption = CONFIG_MAPPER.map(configSource, BigqueryColumnOption.class);
+    PluginTask task = CONFIG_MAPPER.map(config, PluginTask.class);
 
-        BigqueryDoubleConverter.convertAndSet(node, "key", 1.0, BigqueryColumnOptionType.TIMESTAMP);
+    BigqueryDoubleConverter.convertAndSet(node, "key", 1.0, BigqueryColumnOptionType.TIMESTAMP);
 
-        assertEquals(node.get("key").asDouble(),1.0, 0);
-    }
+    assertEquals(node.get("key").asDouble(), 1.0, 0);
+  }
 }

--- a/src/test/java/org/embulk/output/bigquery_java/converter/TestBigqueryLongConverter.java
+++ b/src/test/java/org/embulk/output/bigquery_java/converter/TestBigqueryLongConverter.java
@@ -19,112 +19,113 @@ import org.junit.Rule;
 import org.junit.Test;
 
 public class TestBigqueryLongConverter {
-    protected static final ConfigMapperFactory CONFIG_MAPPER_FACTORY =
-            ConfigMapperFactory.builder().addDefaultModules().build();
+  protected static final ConfigMapperFactory CONFIG_MAPPER_FACTORY =
+      ConfigMapperFactory.builder().addDefaultModules().build();
 
-    protected static final ConfigMapper CONFIG_MAPPER = CONFIG_MAPPER_FACTORY.createConfigMapper();
+  protected static final ConfigMapper CONFIG_MAPPER = CONFIG_MAPPER_FACTORY.createConfigMapper();
 
-    private ConfigSource config;
-    private static final String BASIC_RESOURCE_PATH = "/java/org/embulk/output/bigquery_java/";
+  private ConfigSource config;
+  private static final String BASIC_RESOURCE_PATH = "/java/org/embulk/output/bigquery_java/";
 
-    private static ConfigSource loadYamlResource(TestingEmbulk embulk, String fileName) {
-        return embulk.loadYamlResource(BASIC_RESOURCE_PATH + fileName);
-    }
+  private static ConfigSource loadYamlResource(TestingEmbulk embulk, String fileName) {
+    return embulk.loadYamlResource(BASIC_RESOURCE_PATH + fileName);
+  }
 
-    @Rule
-    public TestingEmbulk embulk = TestingEmbulk.builder()
-            .registerPlugin(OutputPlugin.class, "bigquery_java", BigqueryJavaOutputPlugin.class)
-            .build();
+  @Rule
+  public TestingEmbulk embulk =
+      TestingEmbulk.builder()
+          .registerPlugin(OutputPlugin.class, "bigquery_java", BigqueryJavaOutputPlugin.class)
+          .build();
 
-    @Test
-    public void testConvertLongToString() {
-        ObjectNode node = BigqueryUtil.getObjectMapper().createObjectNode();
-        config = loadYamlResource(embulk, "base.yml");
-        List<ConfigSource> configSources = new ArrayList<>();
-        ConfigSource configSource = embulk.newConfig();
-        configSource.set("type", "STRING");
-        configSource.set("name", "key");
-        configSources.add(configSource);
-        config.set("column_options", configSources);
-        BigqueryColumnOption columnOption = CONFIG_MAPPER.map(configSource, BigqueryColumnOption.class);
-        PluginTask task = CONFIG_MAPPER.map(config, PluginTask.class);
+  @Test
+  public void testConvertLongToString() {
+    ObjectNode node = BigqueryUtil.getObjectMapper().createObjectNode();
+    config = loadYamlResource(embulk, "base.yml");
+    List<ConfigSource> configSources = new ArrayList<>();
+    ConfigSource configSource = embulk.newConfig();
+    configSource.set("type", "STRING");
+    configSource.set("name", "key");
+    configSources.add(configSource);
+    config.set("column_options", configSources);
+    BigqueryColumnOption columnOption = CONFIG_MAPPER.map(configSource, BigqueryColumnOption.class);
+    PluginTask task = CONFIG_MAPPER.map(config, PluginTask.class);
 
-        BigqueryLongConverter.convertAndSet(node, "key", 1L, BigqueryColumnOptionType.STRING);
+    BigqueryLongConverter.convertAndSet(node, "key", 1L, BigqueryColumnOptionType.STRING);
 
-        assertEquals(node.get("key").asText(),"1");
-    }
+    assertEquals(node.get("key").asText(), "1");
+  }
 
-    @Test
-    public void testConvertLongToInteger() {
-        ObjectNode node = BigqueryUtil.getObjectMapper().createObjectNode();
-        config = loadYamlResource(embulk, "base.yml");
-        List<ConfigSource> configSources = new ArrayList<>();
-        ConfigSource configSource = embulk.newConfig();
-        configSource.set("type", "INTEGER");
-        configSource.set("name", "key");
-        configSources.add(configSource);
-        config.set("column_options", configSources);
-        BigqueryColumnOption columnOption = CONFIG_MAPPER.map(configSource, BigqueryColumnOption.class);
-        PluginTask task = CONFIG_MAPPER.map(config, PluginTask.class);
+  @Test
+  public void testConvertLongToInteger() {
+    ObjectNode node = BigqueryUtil.getObjectMapper().createObjectNode();
+    config = loadYamlResource(embulk, "base.yml");
+    List<ConfigSource> configSources = new ArrayList<>();
+    ConfigSource configSource = embulk.newConfig();
+    configSource.set("type", "INTEGER");
+    configSource.set("name", "key");
+    configSources.add(configSource);
+    config.set("column_options", configSources);
+    BigqueryColumnOption columnOption = CONFIG_MAPPER.map(configSource, BigqueryColumnOption.class);
+    PluginTask task = CONFIG_MAPPER.map(config, PluginTask.class);
 
-        BigqueryLongConverter.convertAndSet(node, "key", 1L, BigqueryColumnOptionType.INTEGER);
+    BigqueryLongConverter.convertAndSet(node, "key", 1L, BigqueryColumnOptionType.INTEGER);
 
-        assertEquals(node.get("key").asLong(),1L);
-    }
+    assertEquals(node.get("key").asLong(), 1L);
+  }
 
-    @Test
-    public void testConvertLongToFloat() {
-        ObjectNode node = BigqueryUtil.getObjectMapper().createObjectNode();
-        config = loadYamlResource(embulk, "base.yml");
-        List<ConfigSource> configSources = new ArrayList<>();
-        ConfigSource configSource = embulk.newConfig();
-        configSource.set("type", "FLOAT");
-        configSource.set("name", "key");
-        configSources.add(configSource);
-        config.set("column_options", configSources);
-        BigqueryColumnOption columnOption = CONFIG_MAPPER.map(configSource, BigqueryColumnOption.class);
-        PluginTask task = CONFIG_MAPPER.map(config, PluginTask.class);
+  @Test
+  public void testConvertLongToFloat() {
+    ObjectNode node = BigqueryUtil.getObjectMapper().createObjectNode();
+    config = loadYamlResource(embulk, "base.yml");
+    List<ConfigSource> configSources = new ArrayList<>();
+    ConfigSource configSource = embulk.newConfig();
+    configSource.set("type", "FLOAT");
+    configSource.set("name", "key");
+    configSources.add(configSource);
+    config.set("column_options", configSources);
+    BigqueryColumnOption columnOption = CONFIG_MAPPER.map(configSource, BigqueryColumnOption.class);
+    PluginTask task = CONFIG_MAPPER.map(config, PluginTask.class);
 
-        BigqueryLongConverter.convertAndSet(node, "key", 1L, BigqueryColumnOptionType.FLOAT);
+    BigqueryLongConverter.convertAndSet(node, "key", 1L, BigqueryColumnOptionType.FLOAT);
 
-        assertEquals(node.get("key").asDouble(),1.0, 0);
-    }
+    assertEquals(node.get("key").asDouble(), 1.0, 0);
+  }
 
-    @Test
-    public void testConvertLongToTimestamp() {
-        ObjectNode node = BigqueryUtil.getObjectMapper().createObjectNode();
-        config = loadYamlResource(embulk, "base.yml");
-        List<ConfigSource> configSources = new ArrayList<>();
-        ConfigSource configSource = embulk.newConfig();
-        configSource.set("type", "TIMESTAMP");
-        configSource.set("name", "key");
-        configSources.add(configSource);
-        config.set("column_options", configSources);
-        BigqueryColumnOption columnOption = CONFIG_MAPPER.map(configSource, BigqueryColumnOption.class);
-        PluginTask task = CONFIG_MAPPER.map(config, PluginTask.class);
+  @Test
+  public void testConvertLongToTimestamp() {
+    ObjectNode node = BigqueryUtil.getObjectMapper().createObjectNode();
+    config = loadYamlResource(embulk, "base.yml");
+    List<ConfigSource> configSources = new ArrayList<>();
+    ConfigSource configSource = embulk.newConfig();
+    configSource.set("type", "TIMESTAMP");
+    configSource.set("name", "key");
+    configSources.add(configSource);
+    config.set("column_options", configSources);
+    BigqueryColumnOption columnOption = CONFIG_MAPPER.map(configSource, BigqueryColumnOption.class);
+    PluginTask task = CONFIG_MAPPER.map(config, PluginTask.class);
 
-        BigqueryLongConverter.convertAndSet(node, "key", 1L, BigqueryColumnOptionType.TIMESTAMP);
+    BigqueryLongConverter.convertAndSet(node, "key", 1L, BigqueryColumnOptionType.TIMESTAMP);
 
-        assertEquals(node.get("key").asLong(),1L);
-    }
+    assertEquals(node.get("key").asLong(), 1L);
+  }
 
-    @Test
-    public void testConvertLongToBoolean() {
-        ObjectNode node = BigqueryUtil.getObjectMapper().createObjectNode();
-        config = loadYamlResource(embulk, "base.yml");
-        List<ConfigSource> configSources = new ArrayList<>();
-        ConfigSource configSource = embulk.newConfig();
-        configSource.set("type", "BOOLEAN");
-        configSource.set("name", "key");
-        configSources.add(configSource);
-        config.set("column_options", configSources);
-        BigqueryColumnOption columnOption = CONFIG_MAPPER.map(configSource, BigqueryColumnOption.class);
-        PluginTask task = CONFIG_MAPPER.map(config, PluginTask.class);
+  @Test
+  public void testConvertLongToBoolean() {
+    ObjectNode node = BigqueryUtil.getObjectMapper().createObjectNode();
+    config = loadYamlResource(embulk, "base.yml");
+    List<ConfigSource> configSources = new ArrayList<>();
+    ConfigSource configSource = embulk.newConfig();
+    configSource.set("type", "BOOLEAN");
+    configSource.set("name", "key");
+    configSources.add(configSource);
+    config.set("column_options", configSources);
+    BigqueryColumnOption columnOption = CONFIG_MAPPER.map(configSource, BigqueryColumnOption.class);
+    PluginTask task = CONFIG_MAPPER.map(config, PluginTask.class);
 
-        BigqueryLongConverter.convertAndSet(node, "key", 1L, BigqueryColumnOptionType.BOOLEAN);
-        assertTrue(node.get("key").asBoolean());
+    BigqueryLongConverter.convertAndSet(node, "key", 1L, BigqueryColumnOptionType.BOOLEAN);
+    assertTrue(node.get("key").asBoolean());
 
-        BigqueryLongConverter.convertAndSet(node, "key", 0L, BigqueryColumnOptionType.BOOLEAN);
-        assertFalse(node.get("key").asBoolean());
-    }
+    BigqueryLongConverter.convertAndSet(node, "key", 0L, BigqueryColumnOptionType.BOOLEAN);
+    assertFalse(node.get("key").asBoolean());
+  }
 }

--- a/src/test/java/org/embulk/output/bigquery_java/converter/TestBigqueryStringConverter.java
+++ b/src/test/java/org/embulk/output/bigquery_java/converter/TestBigqueryStringConverter.java
@@ -22,212 +22,237 @@ import org.junit.Rule;
 import org.junit.Test;
 
 public class TestBigqueryStringConverter {
-    protected static final ConfigMapperFactory CONFIG_MAPPER_FACTORY =
-            ConfigMapperFactory.builder().addDefaultModules().build();
+  protected static final ConfigMapperFactory CONFIG_MAPPER_FACTORY =
+      ConfigMapperFactory.builder().addDefaultModules().build();
 
-    protected static final ConfigMapper CONFIG_MAPPER = CONFIG_MAPPER_FACTORY.createConfigMapper();
+  protected static final ConfigMapper CONFIG_MAPPER = CONFIG_MAPPER_FACTORY.createConfigMapper();
 
-    private ConfigSource config;
-    private static final String BASIC_RESOURCE_PATH = "/java/org/embulk/output/bigquery_java/";
+  private ConfigSource config;
+  private static final String BASIC_RESOURCE_PATH = "/java/org/embulk/output/bigquery_java/";
 
-    private static ConfigSource loadYamlResource(TestingEmbulk embulk, String fileName) {
-        return embulk.loadYamlResource(BASIC_RESOURCE_PATH + fileName);
-    }
+  private static ConfigSource loadYamlResource(TestingEmbulk embulk, String fileName) {
+    return embulk.loadYamlResource(BASIC_RESOURCE_PATH + fileName);
+  }
 
-    @Rule
-    public TestingEmbulk embulk = TestingEmbulk.builder()
-            .registerPlugin(OutputPlugin.class, "bigquery_java", BigqueryJavaOutputPlugin.class)
-            .build();
+  @Rule
+  public TestingEmbulk embulk =
+      TestingEmbulk.builder()
+          .registerPlugin(OutputPlugin.class, "bigquery_java", BigqueryJavaOutputPlugin.class)
+          .build();
 
-    @Test
-    public void testConvertStringToString() {
-        ObjectNode node = BigqueryUtil.getObjectMapper().createObjectNode();
-        config = loadYamlResource(embulk, "base.yml");
-        List<ConfigSource> configSources = new ArrayList<>();
-        ConfigSource configSource = embulk.newConfig();
-        configSource.set("type", "STRING");
-        configSource.set("name", "key");
-        configSources.add(configSource);
-        config.set("column_options", configSources);
-        BigqueryColumnOption columnOption = CONFIG_MAPPER.map(configSource, BigqueryColumnOption.class);
-        PluginTask task = CONFIG_MAPPER.map(config, PluginTask.class);
+  @Test
+  public void testConvertStringToString() {
+    ObjectNode node = BigqueryUtil.getObjectMapper().createObjectNode();
+    config = loadYamlResource(embulk, "base.yml");
+    List<ConfigSource> configSources = new ArrayList<>();
+    ConfigSource configSource = embulk.newConfig();
+    configSource.set("type", "STRING");
+    configSource.set("name", "key");
+    configSources.add(configSource);
+    config.set("column_options", configSources);
+    BigqueryColumnOption columnOption = CONFIG_MAPPER.map(configSource, BigqueryColumnOption.class);
+    PluginTask task = CONFIG_MAPPER.map(config, PluginTask.class);
 
-        BigqueryStringConverter.convertAndSet(node, "key", "data", BigqueryColumnOptionType.STRING, columnOption);
+    BigqueryStringConverter.convertAndSet(
+        node, "key", "data", BigqueryColumnOptionType.STRING, columnOption);
 
-        assertEquals("data", node.get("key").asText());
-    }
+    assertEquals("data", node.get("key").asText());
+  }
 
-    @Test
-    public void testConvertStringToInt() {
-        ObjectNode node = BigqueryUtil.getObjectMapper().createObjectNode();
-        config = loadYamlResource(embulk, "base.yml");
-        List<ConfigSource> configSources = new ArrayList<>();
-        ConfigSource configSource = embulk.newConfig();
-        configSource.set("type", "INTEGER");
-        configSource.set("name", "key");
-        configSources.add(configSource);
-        config.set("column_options", configSources);
-        BigqueryColumnOption columnOption = CONFIG_MAPPER.map(configSource, BigqueryColumnOption.class);
-        PluginTask task = CONFIG_MAPPER.map(config, PluginTask.class);
+  @Test
+  public void testConvertStringToInt() {
+    ObjectNode node = BigqueryUtil.getObjectMapper().createObjectNode();
+    config = loadYamlResource(embulk, "base.yml");
+    List<ConfigSource> configSources = new ArrayList<>();
+    ConfigSource configSource = embulk.newConfig();
+    configSource.set("type", "INTEGER");
+    configSource.set("name", "key");
+    configSources.add(configSource);
+    config.set("column_options", configSources);
+    BigqueryColumnOption columnOption = CONFIG_MAPPER.map(configSource, BigqueryColumnOption.class);
+    PluginTask task = CONFIG_MAPPER.map(config, PluginTask.class);
 
-        BigqueryStringConverter.convertAndSet(node, "key", "1", BigqueryColumnOptionType.INTEGER, columnOption);
+    BigqueryStringConverter.convertAndSet(
+        node, "key", "1", BigqueryColumnOptionType.INTEGER, columnOption);
 
-        assertEquals(1, node.get("key").asInt());
-    }
+    assertEquals(1, node.get("key").asInt());
+  }
 
-    @Test
-    public void testConvertStringToFloat() {
-        ObjectNode node = BigqueryUtil.getObjectMapper().createObjectNode();
-        config = loadYamlResource(embulk, "base.yml");
-        List<ConfigSource> configSources = new ArrayList<>();
-        ConfigSource configSource = embulk.newConfig();
-        configSource.set("type", "FLOAT");
-        configSource.set("name", "key");
-        configSources.add(configSource);
-        config.set("column_options", configSources);
-        BigqueryColumnOption columnOption = CONFIG_MAPPER.map(configSource, BigqueryColumnOption.class);
-        PluginTask task = CONFIG_MAPPER.map(config, PluginTask.class);
+  @Test
+  public void testConvertStringToFloat() {
+    ObjectNode node = BigqueryUtil.getObjectMapper().createObjectNode();
+    config = loadYamlResource(embulk, "base.yml");
+    List<ConfigSource> configSources = new ArrayList<>();
+    ConfigSource configSource = embulk.newConfig();
+    configSource.set("type", "FLOAT");
+    configSource.set("name", "key");
+    configSources.add(configSource);
+    config.set("column_options", configSources);
+    BigqueryColumnOption columnOption = CONFIG_MAPPER.map(configSource, BigqueryColumnOption.class);
+    PluginTask task = CONFIG_MAPPER.map(config, PluginTask.class);
 
-        BigqueryStringConverter.convertAndSet(node, "key", "1.0", BigqueryColumnOptionType.FLOAT, columnOption);
+    BigqueryStringConverter.convertAndSet(
+        node, "key", "1.0", BigqueryColumnOptionType.FLOAT, columnOption);
 
-        assertEquals(1.0, node.get("key").asDouble(), 0);
-    }
+    assertEquals(1.0, node.get("key").asDouble(), 0);
+  }
 
-    @Test
-    public void testConvertStringToDate() {
-        ObjectNode node = BigqueryUtil.getObjectMapper().createObjectNode();
-        config = loadYamlResource(embulk, "base.yml");
-        List<ConfigSource> configSources = new ArrayList<>();
-        ConfigSource configSource = embulk.newConfig();
-        configSource.set("type", "DATE");
-        configSource.set("name", "key");
-        configSource.set("timestamp_format", "%Y/%m/%d");
-        configSources.add(configSource);
-        config.set("column_options", configSources);
-        BigqueryColumnOption columnOption = CONFIG_MAPPER.map(configSource, BigqueryColumnOption.class);
-        PluginTask task = CONFIG_MAPPER.map(config, PluginTask.class);
+  @Test
+  public void testConvertStringToDate() {
+    ObjectNode node = BigqueryUtil.getObjectMapper().createObjectNode();
+    config = loadYamlResource(embulk, "base.yml");
+    List<ConfigSource> configSources = new ArrayList<>();
+    ConfigSource configSource = embulk.newConfig();
+    configSource.set("type", "DATE");
+    configSource.set("name", "key");
+    configSource.set("timestamp_format", "%Y/%m/%d");
+    configSources.add(configSource);
+    config.set("column_options", configSources);
+    BigqueryColumnOption columnOption = CONFIG_MAPPER.map(configSource, BigqueryColumnOption.class);
+    PluginTask task = CONFIG_MAPPER.map(config, PluginTask.class);
 
-        BigqueryStringConverter.convertAndSet(node, "key", "2020/05/01", BigqueryColumnOptionType.DATE, columnOption);
-        assertEquals("2020-05-01", node.get("key").asText());
+    BigqueryStringConverter.convertAndSet(
+        node, "key", "2020/05/01", BigqueryColumnOptionType.DATE, columnOption);
+    assertEquals("2020-05-01", node.get("key").asText());
 
-        assertThrows(BigqueryTypeCastException.class, () -> {
-            BigqueryStringConverter.convertAndSet(node, "key", "20200501", BigqueryColumnOptionType.DATE, columnOption);
+    assertThrows(
+        BigqueryTypeCastException.class,
+        () -> {
+          BigqueryStringConverter.convertAndSet(
+              node, "key", "20200501", BigqueryColumnOptionType.DATE, columnOption);
         });
-    }
+  }
 
-    @Test
-    public void testConvertStringToDate_withoutTimeFormat() {
-        ObjectNode node = BigqueryUtil.getObjectMapper().createObjectNode();
-        config = loadYamlResource(embulk, "base.yml");
-        List<ConfigSource> configSources = new ArrayList<>();
-        ConfigSource configSource = embulk.newConfig();
-        configSource.set("type", "DATE");
-        configSource.set("name", "key");
-        configSources.add(configSource);
-        config.set("column_options", configSources);
-        BigqueryColumnOption columnOption = CONFIG_MAPPER.map(configSource, BigqueryColumnOption.class);
-        PluginTask task = CONFIG_MAPPER.map(config, PluginTask.class);
+  @Test
+  public void testConvertStringToDate_withoutTimeFormat() {
+    ObjectNode node = BigqueryUtil.getObjectMapper().createObjectNode();
+    config = loadYamlResource(embulk, "base.yml");
+    List<ConfigSource> configSources = new ArrayList<>();
+    ConfigSource configSource = embulk.newConfig();
+    configSource.set("type", "DATE");
+    configSource.set("name", "key");
+    configSources.add(configSource);
+    config.set("column_options", configSources);
+    BigqueryColumnOption columnOption = CONFIG_MAPPER.map(configSource, BigqueryColumnOption.class);
+    PluginTask task = CONFIG_MAPPER.map(config, PluginTask.class);
 
-        BigqueryStringConverter.convertAndSet(node, "key", "2020-05-01", BigqueryColumnOptionType.DATE, columnOption);
-        assertEquals("2020-05-01", node.get("key").asText());
+    BigqueryStringConverter.convertAndSet(
+        node, "key", "2020-05-01", BigqueryColumnOptionType.DATE, columnOption);
+    assertEquals("2020-05-01", node.get("key").asText());
 
-        BigqueryStringConverter.convertAndSet(node, "key", "2020/05/01", BigqueryColumnOptionType.DATE, columnOption);
-        assertEquals("2020/05/01", node.get("key").asText());
-    }
+    BigqueryStringConverter.convertAndSet(
+        node, "key", "2020/05/01", BigqueryColumnOptionType.DATE, columnOption);
+    assertEquals("2020/05/01", node.get("key").asText());
+  }
 
-    @Test
-    public void testConvertStringToDatetime() {
-        ObjectNode node = BigqueryUtil.getObjectMapper().createObjectNode();
-        config = loadYamlResource(embulk, "base.yml");
-        List<ConfigSource> configSources = new ArrayList<>();
-        ConfigSource configSource = embulk.newConfig();
-        configSource.set("type", "DATETIME");
-        configSource.set("name", "key");
-        configSource.set("timestamp_format", "%Y/%m/%d %H:%M:%S");
-        configSources.add(configSource);
-        config.set("column_options", configSources);
-        BigqueryColumnOption columnOption = CONFIG_MAPPER.map(configSource, BigqueryColumnOption.class);
-        PluginTask task = CONFIG_MAPPER.map(config, PluginTask.class);
+  @Test
+  public void testConvertStringToDatetime() {
+    ObjectNode node = BigqueryUtil.getObjectMapper().createObjectNode();
+    config = loadYamlResource(embulk, "base.yml");
+    List<ConfigSource> configSources = new ArrayList<>();
+    ConfigSource configSource = embulk.newConfig();
+    configSource.set("type", "DATETIME");
+    configSource.set("name", "key");
+    configSource.set("timestamp_format", "%Y/%m/%d %H:%M:%S");
+    configSources.add(configSource);
+    config.set("column_options", configSources);
+    BigqueryColumnOption columnOption = CONFIG_MAPPER.map(configSource, BigqueryColumnOption.class);
+    PluginTask task = CONFIG_MAPPER.map(config, PluginTask.class);
 
-        BigqueryStringConverter.convertAndSet(node, "key", "2020/05/01 00:00:00", BigqueryColumnOptionType.DATETIME, columnOption);
+    BigqueryStringConverter.convertAndSet(
+        node, "key", "2020/05/01 00:00:00", BigqueryColumnOptionType.DATETIME, columnOption);
 
-        assertEquals("2020-05-01 00:00:00.000000", node.get("key").asText());
-    }
+    assertEquals("2020-05-01 00:00:00.000000", node.get("key").asText());
+  }
 
-    @Test
-    public void testConvertStringToDatetime_withoutTimeFormat() {
-        ObjectNode node = BigqueryUtil.getObjectMapper().createObjectNode();
-        config = loadYamlResource(embulk, "base.yml");
-        List<ConfigSource> configSources = new ArrayList<>();
-        ConfigSource configSource = embulk.newConfig();
-        configSource.set("type", "DATETIME");
-        configSource.set("name", "key");
-        configSources.add(configSource);
-        config.set("column_options", configSources);
-        BigqueryColumnOption columnOption = CONFIG_MAPPER.map(configSource, BigqueryColumnOption.class);
-        PluginTask task = CONFIG_MAPPER.map(config, PluginTask.class);
+  @Test
+  public void testConvertStringToDatetime_withoutTimeFormat() {
+    ObjectNode node = BigqueryUtil.getObjectMapper().createObjectNode();
+    config = loadYamlResource(embulk, "base.yml");
+    List<ConfigSource> configSources = new ArrayList<>();
+    ConfigSource configSource = embulk.newConfig();
+    configSource.set("type", "DATETIME");
+    configSource.set("name", "key");
+    configSources.add(configSource);
+    config.set("column_options", configSources);
+    BigqueryColumnOption columnOption = CONFIG_MAPPER.map(configSource, BigqueryColumnOption.class);
+    PluginTask task = CONFIG_MAPPER.map(config, PluginTask.class);
 
-        BigqueryStringConverter.convertAndSet(node, "key", "2020-05-01 00:00:00.000000", BigqueryColumnOptionType.DATETIME, columnOption);
-        assertEquals("2020-05-01 00:00:00.000000", node.get("key").asText());
+    BigqueryStringConverter.convertAndSet(
+        node, "key", "2020-05-01 00:00:00.000000", BigqueryColumnOptionType.DATETIME, columnOption);
+    assertEquals("2020-05-01 00:00:00.000000", node.get("key").asText());
 
-        BigqueryStringConverter.convertAndSet(node, "key", "2020/05/01 00:00:00.000000", BigqueryColumnOptionType.DATETIME, columnOption);
-        assertEquals("2020/05/01 00:00:00.000000", node.get("key").asText());
-    }
+    BigqueryStringConverter.convertAndSet(
+        node, "key", "2020/05/01 00:00:00.000000", BigqueryColumnOptionType.DATETIME, columnOption);
+    assertEquals("2020/05/01 00:00:00.000000", node.get("key").asText());
+  }
 
-    @Test
-    public void testConvertStringToTimestamp() {
-        ObjectNode node = BigqueryUtil.getObjectMapper().createObjectNode();
-        config = loadYamlResource(embulk, "base.yml");
-        List<ConfigSource> configSources = new ArrayList<>();
-        ConfigSource configSource = embulk.newConfig();
-        configSource.set("type", "TIMESTAMP");
-        configSource.set("name", "key");
-        configSource.set("timestamp_format", "%Y/%m/%d %H:%M:%S");
-        configSources.add(configSource);
-        config.set("column_options", configSources);
-        BigqueryColumnOption columnOption = CONFIG_MAPPER.map(configSource, BigqueryColumnOption.class);
-        PluginTask task = CONFIG_MAPPER.map(config, PluginTask.class);
+  @Test
+  public void testConvertStringToTimestamp() {
+    ObjectNode node = BigqueryUtil.getObjectMapper().createObjectNode();
+    config = loadYamlResource(embulk, "base.yml");
+    List<ConfigSource> configSources = new ArrayList<>();
+    ConfigSource configSource = embulk.newConfig();
+    configSource.set("type", "TIMESTAMP");
+    configSource.set("name", "key");
+    configSource.set("timestamp_format", "%Y/%m/%d %H:%M:%S");
+    configSources.add(configSource);
+    config.set("column_options", configSources);
+    BigqueryColumnOption columnOption = CONFIG_MAPPER.map(configSource, BigqueryColumnOption.class);
+    PluginTask task = CONFIG_MAPPER.map(config, PluginTask.class);
 
-        BigqueryStringConverter.convertAndSet(node, "key", "2020/05/01 00:00:00", BigqueryColumnOptionType.TIMESTAMP, columnOption);
+    BigqueryStringConverter.convertAndSet(
+        node, "key", "2020/05/01 00:00:00", BigqueryColumnOptionType.TIMESTAMP, columnOption);
 
-        assertEquals("2020-05-01 00:00:00.000000 +00:00", node.get("key").asText());
-    }
+    assertEquals("2020-05-01 00:00:00.000000 +00:00", node.get("key").asText());
+  }
 
-    @Test
-    public void testConvertStringToTimestamp_withoutTimeFormat() {
-        ObjectNode node = BigqueryUtil.getObjectMapper().createObjectNode();
-        config = loadYamlResource(embulk, "base.yml");
-        List<ConfigSource> configSources = new ArrayList<>();
-        ConfigSource configSource = embulk.newConfig();
-        configSource.set("type", "TIMESTAMP");
-        configSource.set("name", "key");
-        configSources.add(configSource);
-        config.set("column_options", configSources);
-        BigqueryColumnOption columnOption = CONFIG_MAPPER.map(configSource, BigqueryColumnOption.class);
-        PluginTask task = CONFIG_MAPPER.map(config, PluginTask.class);
+  @Test
+  public void testConvertStringToTimestamp_withoutTimeFormat() {
+    ObjectNode node = BigqueryUtil.getObjectMapper().createObjectNode();
+    config = loadYamlResource(embulk, "base.yml");
+    List<ConfigSource> configSources = new ArrayList<>();
+    ConfigSource configSource = embulk.newConfig();
+    configSource.set("type", "TIMESTAMP");
+    configSource.set("name", "key");
+    configSources.add(configSource);
+    config.set("column_options", configSources);
+    BigqueryColumnOption columnOption = CONFIG_MAPPER.map(configSource, BigqueryColumnOption.class);
+    PluginTask task = CONFIG_MAPPER.map(config, PluginTask.class);
 
-        BigqueryStringConverter.convertAndSet(node, "key", "2020-05-01 00:00:00.000000 +09:00", BigqueryColumnOptionType.TIMESTAMP, columnOption);
-        assertEquals("2020-05-01 00:00:00.000000 +09:00", node.get("key").asText());
+    BigqueryStringConverter.convertAndSet(
+        node,
+        "key",
+        "2020-05-01 00:00:00.000000 +09:00",
+        BigqueryColumnOptionType.TIMESTAMP,
+        columnOption);
+    assertEquals("2020-05-01 00:00:00.000000 +09:00", node.get("key").asText());
 
-        BigqueryStringConverter.convertAndSet(node, "key", "2020/05/01 00:00:00.000000 +09:00", BigqueryColumnOptionType.TIMESTAMP, columnOption);
-        assertEquals("2020/05/01 00:00:00.000000 +09:00", node.get("key").asText());
-    }
+    BigqueryStringConverter.convertAndSet(
+        node,
+        "key",
+        "2020/05/01 00:00:00.000000 +09:00",
+        BigqueryColumnOptionType.TIMESTAMP,
+        columnOption);
+    assertEquals("2020/05/01 00:00:00.000000 +09:00", node.get("key").asText());
+  }
 
-    @Test
-    public void testConvertStringToNumeric() {
-        ObjectNode node = BigqueryUtil.getObjectMapper().createObjectNode();
-        config = loadYamlResource(embulk, "base.yml");
-        List<ConfigSource> configSources = new ArrayList<>();
-        ConfigSource configSource = embulk.newConfig();
-        configSource.set("type", "NUMERIC");
-        configSource.set("name", "key");
-        configSources.add(configSource);
-        config.set("column_options", configSources);
-        BigqueryColumnOption columnOption = CONFIG_MAPPER.map(configSource, BigqueryColumnOption.class);
-        PluginTask task = CONFIG_MAPPER.map(config, PluginTask.class);
-        BigqueryStringConverter.convertAndSet(node, "key", "123.456", BigqueryColumnOptionType.NUMERIC, columnOption);
+  @Test
+  public void testConvertStringToNumeric() {
+    ObjectNode node = BigqueryUtil.getObjectMapper().createObjectNode();
+    config = loadYamlResource(embulk, "base.yml");
+    List<ConfigSource> configSources = new ArrayList<>();
+    ConfigSource configSource = embulk.newConfig();
+    configSource.set("type", "NUMERIC");
+    configSource.set("name", "key");
+    configSources.add(configSource);
+    config.set("column_options", configSources);
+    BigqueryColumnOption columnOption = CONFIG_MAPPER.map(configSource, BigqueryColumnOption.class);
+    PluginTask task = CONFIG_MAPPER.map(config, PluginTask.class);
+    BigqueryStringConverter.convertAndSet(
+        node, "key", "123.456", BigqueryColumnOptionType.NUMERIC, columnOption);
 
-        assertTrue(node.get("key").isBigDecimal());
-        assertEquals(123.456, node.get("key").asDouble(), 0);
-    }
+    assertTrue(node.get("key").isBigDecimal());
+    assertEquals(123.456, node.get("key").asDouble(), 0);
+  }
 }

--- a/src/test/java/org/embulk/output/bigquery_java/converter/TestBigqueryTimestampConverter.java
+++ b/src/test/java/org/embulk/output/bigquery_java/converter/TestBigqueryTimestampConverter.java
@@ -19,151 +19,160 @@ import org.junit.Rule;
 import org.junit.Test;
 
 public class TestBigqueryTimestampConverter {
-    private static final ConfigMapperFactory CONFIG_MAPPER_FACTORY = ConfigMapperFactory.builder().addDefaultModules().build();
-    private static final ConfigMapper CONFIG_MAPPER = CONFIG_MAPPER_FACTORY.createConfigMapper();
+  private static final ConfigMapperFactory CONFIG_MAPPER_FACTORY =
+      ConfigMapperFactory.builder().addDefaultModules().build();
+  private static final ConfigMapper CONFIG_MAPPER = CONFIG_MAPPER_FACTORY.createConfigMapper();
 
-    private ConfigSource config;
-    private static final String BASIC_RESOURCE_PATH = "/java/org/embulk/output/bigquery_java/";
+  private ConfigSource config;
+  private static final String BASIC_RESOURCE_PATH = "/java/org/embulk/output/bigquery_java/";
 
-    private static ConfigSource loadYamlResource(TestingEmbulk embulk, String fileName) {
-        return embulk.loadYamlResource(BASIC_RESOURCE_PATH + fileName);
-    }
+  private static ConfigSource loadYamlResource(TestingEmbulk embulk, String fileName) {
+    return embulk.loadYamlResource(BASIC_RESOURCE_PATH + fileName);
+  }
 
-    @Rule
-    public TestingEmbulk embulk = TestingEmbulk.builder()
-            .registerPlugin(OutputPlugin.class, "bigquery_java", BigqueryJavaOutputPlugin.class)
-            .build();
+  @Rule
+  public TestingEmbulk embulk =
+      TestingEmbulk.builder()
+          .registerPlugin(OutputPlugin.class, "bigquery_java", BigqueryJavaOutputPlugin.class)
+          .build();
 
-    @SuppressWarnings("deprecation") // The use of org.embulk.spi.time.Timestamp
-    @Test
-    public void testConvertTimestampToInteger() {
-        ObjectNode node = BigqueryUtil.getObjectMapper().createObjectNode();
-        config = loadYamlResource(embulk, "base.yml");
-        List<ConfigSource> configSources = new ArrayList<>();
-        ConfigSource configSource = embulk.newConfig();
-        configSource.set("type", "INTEGER");
-        configSource.set("name", "key");
-        configSources.add(configSource);
-        config.set("column_options", configSources);
-        BigqueryColumnOption columnOption = CONFIG_MAPPER.map(configSource, BigqueryColumnOption.class);
-        PluginTask task = CONFIG_MAPPER.map(config, PluginTask.class);
-        org.embulk.spi.time.Timestamp ts = org.embulk.spi.time.Timestamp.ofEpochMilli(1588291200000L);
+  @SuppressWarnings("deprecation") // The use of org.embulk.spi.time.Timestamp
+  @Test
+  public void testConvertTimestampToInteger() {
+    ObjectNode node = BigqueryUtil.getObjectMapper().createObjectNode();
+    config = loadYamlResource(embulk, "base.yml");
+    List<ConfigSource> configSources = new ArrayList<>();
+    ConfigSource configSource = embulk.newConfig();
+    configSource.set("type", "INTEGER");
+    configSource.set("name", "key");
+    configSources.add(configSource);
+    config.set("column_options", configSources);
+    BigqueryColumnOption columnOption = CONFIG_MAPPER.map(configSource, BigqueryColumnOption.class);
+    PluginTask task = CONFIG_MAPPER.map(config, PluginTask.class);
+    org.embulk.spi.time.Timestamp ts = org.embulk.spi.time.Timestamp.ofEpochMilli(1588291200000L);
 
-        BigqueryTimestampConverter.convertAndSet(node, "key", ts, BigqueryColumnOptionType.INTEGER, columnOption, task);
-        assertEquals(1588291200000L, node.get("key").asLong());
-    }
+    BigqueryTimestampConverter.convertAndSet(
+        node, "key", ts, BigqueryColumnOptionType.INTEGER, columnOption, task);
+    assertEquals(1588291200000L, node.get("key").asLong());
+  }
 
-    @SuppressWarnings("deprecation") // The use of org.embulk.spi.time.Timestamp
-    @Test
-    public void testConvertTimestampToFloat() {
-        ObjectNode node = BigqueryUtil.getObjectMapper().createObjectNode();
-        config = loadYamlResource(embulk, "base.yml");
-        List<ConfigSource> configSources = new ArrayList<>();
-        ConfigSource configSource = embulk.newConfig();
-        configSource.set("type", "FLOAT");
-        configSource.set("name", "key");
-        configSources.add(configSource);
-        config.set("column_options", configSources);
-        BigqueryColumnOption columnOption = CONFIG_MAPPER.map(configSource, BigqueryColumnOption.class);
-        PluginTask task = CONFIG_MAPPER.map(config, PluginTask.class);
-        // Fri May 01 2020 00:00:00
-        org.embulk.spi.time.Timestamp ts = org.embulk.spi.time.Timestamp.ofEpochMilli(1588291200000L);
+  @SuppressWarnings("deprecation") // The use of org.embulk.spi.time.Timestamp
+  @Test
+  public void testConvertTimestampToFloat() {
+    ObjectNode node = BigqueryUtil.getObjectMapper().createObjectNode();
+    config = loadYamlResource(embulk, "base.yml");
+    List<ConfigSource> configSources = new ArrayList<>();
+    ConfigSource configSource = embulk.newConfig();
+    configSource.set("type", "FLOAT");
+    configSource.set("name", "key");
+    configSources.add(configSource);
+    config.set("column_options", configSources);
+    BigqueryColumnOption columnOption = CONFIG_MAPPER.map(configSource, BigqueryColumnOption.class);
+    PluginTask task = CONFIG_MAPPER.map(config, PluginTask.class);
+    // Fri May 01 2020 00:00:00
+    org.embulk.spi.time.Timestamp ts = org.embulk.spi.time.Timestamp.ofEpochMilli(1588291200000L);
 
-        BigqueryTimestampConverter.convertAndSet(node, "key", ts, BigqueryColumnOptionType.FLOAT, columnOption, task);
-        assertEquals(1588291200000L, node.get("key").asLong());
-    }
+    BigqueryTimestampConverter.convertAndSet(
+        node, "key", ts, BigqueryColumnOptionType.FLOAT, columnOption, task);
+    assertEquals(1588291200000L, node.get("key").asLong());
+  }
 
-    @SuppressWarnings("deprecation") // The use of org.embulk.spi.time.Timestamp
-    @Test
-    public void testConvertTimestampToTimestampColumnOption() {
-        ObjectNode node = BigqueryUtil.getObjectMapper().createObjectNode();
-        config = loadYamlResource(embulk, "base.yml");
-        PluginTask task = CONFIG_MAPPER.map(config, PluginTask.class);
-        // Fri May 01 2020 00:00:00
-        org.embulk.spi.time.Timestamp ts = org.embulk.spi.time.Timestamp.ofEpochMilli(1588291200000L);
+  @SuppressWarnings("deprecation") // The use of org.embulk.spi.time.Timestamp
+  @Test
+  public void testConvertTimestampToTimestampColumnOption() {
+    ObjectNode node = BigqueryUtil.getObjectMapper().createObjectNode();
+    config = loadYamlResource(embulk, "base.yml");
+    PluginTask task = CONFIG_MAPPER.map(config, PluginTask.class);
+    // Fri May 01 2020 00:00:00
+    org.embulk.spi.time.Timestamp ts = org.embulk.spi.time.Timestamp.ofEpochMilli(1588291200000L);
 
-        BigqueryTimestampConverter.convertAndSet(node, "key", ts, BigqueryColumnOptionType.TIMESTAMP, null, task);
-        assertEquals("2020-05-01 00:00:00.000000 +00:00", node.get("key").asText());
-    }
+    BigqueryTimestampConverter.convertAndSet(
+        node, "key", ts, BigqueryColumnOptionType.TIMESTAMP, null, task);
+    assertEquals("2020-05-01 00:00:00.000000 +00:00", node.get("key").asText());
+  }
 
-    @SuppressWarnings("deprecation") // The use of org.embulk.spi.time.Timestamp
-    @Test
-    public void testConvertTimestampToString() {
-        ObjectNode node = BigqueryUtil.getObjectMapper().createObjectNode();
-        config = loadYamlResource(embulk, "base.yml");
-        List<ConfigSource> configSources = new ArrayList<>();
-        ConfigSource configSource = embulk.newConfig();
-        configSource.set("type", "STRING");
-        configSource.set("name", "key");
-        configSources.add(configSource);
-        config.set("column_options", configSources);
-        BigqueryColumnOption columnOption = CONFIG_MAPPER.map(configSource, BigqueryColumnOption.class);
-        PluginTask task = CONFIG_MAPPER.map(config, PluginTask.class);
-        // Fri May 01 2020 00:00:00
-        org.embulk.spi.time.Timestamp ts = org.embulk.spi.time.Timestamp.ofEpochMilli(1588291200000L);
+  @SuppressWarnings("deprecation") // The use of org.embulk.spi.time.Timestamp
+  @Test
+  public void testConvertTimestampToString() {
+    ObjectNode node = BigqueryUtil.getObjectMapper().createObjectNode();
+    config = loadYamlResource(embulk, "base.yml");
+    List<ConfigSource> configSources = new ArrayList<>();
+    ConfigSource configSource = embulk.newConfig();
+    configSource.set("type", "STRING");
+    configSource.set("name", "key");
+    configSources.add(configSource);
+    config.set("column_options", configSources);
+    BigqueryColumnOption columnOption = CONFIG_MAPPER.map(configSource, BigqueryColumnOption.class);
+    PluginTask task = CONFIG_MAPPER.map(config, PluginTask.class);
+    // Fri May 01 2020 00:00:00
+    org.embulk.spi.time.Timestamp ts = org.embulk.spi.time.Timestamp.ofEpochMilli(1588291200000L);
 
-        BigqueryTimestampConverter.convertAndSet(node, "key", ts, BigqueryColumnOptionType.STRING, columnOption, task);
-        assertEquals("2020-05-01 00:00:00.000000 +00:00", node.get("key").asText());
-    }
+    BigqueryTimestampConverter.convertAndSet(
+        node, "key", ts, BigqueryColumnOptionType.STRING, columnOption, task);
+    assertEquals("2020-05-01 00:00:00.000000 +00:00", node.get("key").asText());
+  }
 
-    @SuppressWarnings("deprecation") // The use of org.embulk.spi.time.Timestamp
-    @Test
-    public void testConvertTimestampToString_withTimestampFormat() {
-        ObjectNode node = BigqueryUtil.getObjectMapper().createObjectNode();
-        config = loadYamlResource(embulk, "base.yml");
-        List<ConfigSource> configSources = new ArrayList<>();
-        ConfigSource configSource = embulk.newConfig();
-        configSource.set("type", "STRING");
-        configSource.set("name", "key");
-        configSource.set("timestamp_format", "%Y/%m/%d");
-        configSources.add(configSource);
-        config.set("column_options", configSources);
-        BigqueryColumnOption columnOption = CONFIG_MAPPER.map(configSource, BigqueryColumnOption.class);
-        PluginTask task = CONFIG_MAPPER.map(config, PluginTask.class);
-        // Fri May 01 2020 00:00:00
-        org.embulk.spi.time.Timestamp ts = org.embulk.spi.time.Timestamp.ofEpochMilli(1588291200000L);
+  @SuppressWarnings("deprecation") // The use of org.embulk.spi.time.Timestamp
+  @Test
+  public void testConvertTimestampToString_withTimestampFormat() {
+    ObjectNode node = BigqueryUtil.getObjectMapper().createObjectNode();
+    config = loadYamlResource(embulk, "base.yml");
+    List<ConfigSource> configSources = new ArrayList<>();
+    ConfigSource configSource = embulk.newConfig();
+    configSource.set("type", "STRING");
+    configSource.set("name", "key");
+    configSource.set("timestamp_format", "%Y/%m/%d");
+    configSources.add(configSource);
+    config.set("column_options", configSources);
+    BigqueryColumnOption columnOption = CONFIG_MAPPER.map(configSource, BigqueryColumnOption.class);
+    PluginTask task = CONFIG_MAPPER.map(config, PluginTask.class);
+    // Fri May 01 2020 00:00:00
+    org.embulk.spi.time.Timestamp ts = org.embulk.spi.time.Timestamp.ofEpochMilli(1588291200000L);
 
-        BigqueryTimestampConverter.convertAndSet(node, "key", ts, BigqueryColumnOptionType.STRING, columnOption, task);
-        assertEquals("2020/05/01", node.get("key").asText());
-    }
+    BigqueryTimestampConverter.convertAndSet(
+        node, "key", ts, BigqueryColumnOptionType.STRING, columnOption, task);
+    assertEquals("2020/05/01", node.get("key").asText());
+  }
 
-    @SuppressWarnings("deprecation") // The use of org.embulk.spi.time.Timestamp
-    @Test
-    public void testConvertTimestampToDate() {
-        ObjectNode node = BigqueryUtil.getObjectMapper().createObjectNode();
-        config = loadYamlResource(embulk, "base.yml");
-        List<ConfigSource> configSources = new ArrayList<>();
-        ConfigSource configSource = embulk.newConfig();
-        configSource.set("type", "STRING");
-        configSource.set("name", "key");
-        configSources.add(configSource);
-        config.set("column_options", configSources);
-        BigqueryColumnOption columnOption = CONFIG_MAPPER.map(configSource, BigqueryColumnOption.class);
-        PluginTask task = CONFIG_MAPPER.map(config, PluginTask.class);
-        // Fri May 01 2020 00:00:00
-        org.embulk.spi.time.Timestamp ts = org.embulk.spi.time.Timestamp.ofEpochMilli(1588291200000L);
+  @SuppressWarnings("deprecation") // The use of org.embulk.spi.time.Timestamp
+  @Test
+  public void testConvertTimestampToDate() {
+    ObjectNode node = BigqueryUtil.getObjectMapper().createObjectNode();
+    config = loadYamlResource(embulk, "base.yml");
+    List<ConfigSource> configSources = new ArrayList<>();
+    ConfigSource configSource = embulk.newConfig();
+    configSource.set("type", "STRING");
+    configSource.set("name", "key");
+    configSources.add(configSource);
+    config.set("column_options", configSources);
+    BigqueryColumnOption columnOption = CONFIG_MAPPER.map(configSource, BigqueryColumnOption.class);
+    PluginTask task = CONFIG_MAPPER.map(config, PluginTask.class);
+    // Fri May 01 2020 00:00:00
+    org.embulk.spi.time.Timestamp ts = org.embulk.spi.time.Timestamp.ofEpochMilli(1588291200000L);
 
-        BigqueryTimestampConverter.convertAndSet(node, "key", ts, BigqueryColumnOptionType.DATE, columnOption, task);
-        assertEquals("2020-05-01", node.get("key").asText());
-    }
+    BigqueryTimestampConverter.convertAndSet(
+        node, "key", ts, BigqueryColumnOptionType.DATE, columnOption, task);
+    assertEquals("2020-05-01", node.get("key").asText());
+  }
 
-    @SuppressWarnings("deprecation") // The use of org.embulk.spi.time.Timestamp
-    @Test
-    public void testConvertTimestampToDatetime() {
-        ObjectNode node = BigqueryUtil.getObjectMapper().createObjectNode();
-        config = loadYamlResource(embulk, "base.yml");
-        List<ConfigSource> configSources = new ArrayList<>();
-        ConfigSource configSource = embulk.newConfig();
-        configSource.set("type", "STRING");
-        configSource.set("name", "key");
-        configSources.add(configSource);
-        config.set("column_options", configSources);
-        BigqueryColumnOption columnOption = CONFIG_MAPPER.map(configSource, BigqueryColumnOption.class);
-        PluginTask task = CONFIG_MAPPER.map(config, PluginTask.class);
-        // Fri May 01 2020 00:00:00
-        org.embulk.spi.time.Timestamp ts = org.embulk.spi.time.Timestamp.ofEpochMilli(1588291200000L);
+  @SuppressWarnings("deprecation") // The use of org.embulk.spi.time.Timestamp
+  @Test
+  public void testConvertTimestampToDatetime() {
+    ObjectNode node = BigqueryUtil.getObjectMapper().createObjectNode();
+    config = loadYamlResource(embulk, "base.yml");
+    List<ConfigSource> configSources = new ArrayList<>();
+    ConfigSource configSource = embulk.newConfig();
+    configSource.set("type", "STRING");
+    configSource.set("name", "key");
+    configSources.add(configSource);
+    config.set("column_options", configSources);
+    BigqueryColumnOption columnOption = CONFIG_MAPPER.map(configSource, BigqueryColumnOption.class);
+    PluginTask task = CONFIG_MAPPER.map(config, PluginTask.class);
+    // Fri May 01 2020 00:00:00
+    org.embulk.spi.time.Timestamp ts = org.embulk.spi.time.Timestamp.ofEpochMilli(1588291200000L);
 
-        BigqueryTimestampConverter.convertAndSet(node, "key", ts, BigqueryColumnOptionType.DATETIME, columnOption, task);
-        assertEquals("2020-05-01 00:00:00.000000", node.get("key").asText());
-    }
+    BigqueryTimestampConverter.convertAndSet(
+        node, "key", ts, BigqueryColumnOptionType.DATETIME, columnOption, task);
+    assertEquals("2020-05-01 00:00:00.000000", node.get("key").asText());
+  }
 }


### PR DESCRIPTION
googleJavaFormat() of [the base PR](https://github.com/trocco-io/embulk-output-bigquery_java/pull/98) has not not yet been implemented because of the large code differences.
The PR runs googleJavaFormat(). Once you have merged [the base PR](https://github.com/trocco-io/embulk-output-bigquery_java/pull/98), merge this PR.