### PR TITLE
fix: Serialize Object/Array to JSON string in RECORD STRING field conversion

### DIFF
--- a/src/main/java/org/embulk/output/bigquery_java/converter/BigqueryRecordConverter.java
+++ b/src/main/java/org/embulk/output/bigquery_java/converter/BigqueryRecordConverter.java
@@ -60,6 +60,7 @@ public class BigqueryRecordConverter {
     String type = field.getType().toUpperCase();
     switch (type) {
       case "STRING":
+        return convertToString(value);
       case "JSON":
       case "NUMERIC":
         return value;
@@ -84,6 +85,13 @@ public class BigqueryRecordConverter {
         throw new BigqueryNotSupportedTypeException(
             String.format("Unsupported field type: %s", type));
     }
+  }
+
+  private static JsonNode convertToString(JsonNode value) {
+    if (value.isObject() || value.isArray()) {
+      return BigqueryUtil.getObjectMapper().getNodeFactory().textNode(value.toString());
+    }
+    return value;
   }
 
   private static JsonNode convertToBoolean(JsonNode value) {

--- a/src/test/java/org/embulk/output/bigquery_java/converter/TestBigqueryRecordConverter.java
+++ b/src/test/java/org/embulk/output/bigquery_java/converter/TestBigqueryRecordConverter.java
@@ -227,6 +227,43 @@ public class TestBigqueryRecordConverter {
   }
 
   @Test
+  public void testConvertStringFieldWithJsonObjectValue() throws Exception {
+    ObjectNode data = OBJECT_MAPPER.createObjectNode();
+    ObjectNode jsonValue = OBJECT_MAPPER.createObjectNode();
+    jsonValue.put("key", "value");
+    ArrayNode nested = OBJECT_MAPPER.createArrayNode();
+    nested.add(1);
+    nested.add(2);
+    nested.add(3);
+    jsonValue.set("nested", nested);
+    data.set("v", jsonValue);
+
+    List<BigqueryFieldOption> fields = new ArrayList<>();
+    fields.add(createFieldOption("v", "STRING"));
+
+    JsonNode result = BigqueryRecordConverter.convertRecordValue(data, fields, task);
+    assertTrue(result.get("v").isTextual());
+    assertEquals("{\"key\":\"value\",\"nested\":[1,2,3]}", result.get("v").asText());
+  }
+
+  @Test
+  public void testConvertStringFieldWithArrayValue() throws Exception {
+    ObjectNode data = OBJECT_MAPPER.createObjectNode();
+    ArrayNode arrayValue = OBJECT_MAPPER.createArrayNode();
+    arrayValue.add("a");
+    arrayValue.add("b");
+    arrayValue.add("c");
+    data.set("v", arrayValue);
+
+    List<BigqueryFieldOption> fields = new ArrayList<>();
+    fields.add(createFieldOption("v", "STRING"));
+
+    JsonNode result = BigqueryRecordConverter.convertRecordValue(data, fields, task);
+    assertTrue(result.get("v").isTextual());
+    assertEquals("[\"a\",\"b\",\"c\"]", result.get("v").asText());
+  }
+
+  @Test
   public void testConvertJsonField() throws Exception {
     ObjectNode data = OBJECT_MAPPER.createObjectNode();
     ObjectNode jsonValue = OBJECT_MAPPER.createObjectNode();


### PR DESCRIPTION
## Summary
- Fix `convertFieldValue` STRING case to serialize Object/Array values to JSON string instead of passing them through as-is
- When a RECORD column has a nested field typed as STRING whose value is a JSON object/array, the value was kept as ObjectNode/ArrayNode, causing BigQuery load jobs to fail with `JSON object specified for non-record field` error
- Add `convertToString` private method following the same pattern as `convertToBoolean`, `convertToInteger`, `convertToFloat`
- Add test cases for the fix

## Test plan
- [x] `testConvertStringFieldWithJsonObjectValue` — STRING field serializes JSON object to JSON string
- [x] `testConvertStringFieldWithArrayValue` — STRING field serializes JSON array to JSON string
- [x] All existing tests pass

Corresponds to https://github.com/trocco-io/embulk-output-bigquery/pull/48

🤖 Generated with [Claude Code](https://claude.com/claude-code)